### PR TITLE
[Feat] #11 - 역대 콘테스트를 보여주는 AllTimeContest 모듈 구현

### DIFF
--- a/Soongan/DesignSystem/Sources/Component/ImageGridView.swift
+++ b/Soongan/DesignSystem/Sources/Component/ImageGridView.swift
@@ -154,8 +154,8 @@ public struct ImageGridView: View {
 
 public struct ContestImageModel: Identifiable, Hashable {
     public let id = UUID()
-    let imageName: String // 원본 이미지 이름 추가
-    let contestImage: Image
+    public let imageName: String // 원본 이미지 이름 추가
+    public let contestImage: Image
     
     public init(imageName: String, contestImage: Image) {
         self.imageName = imageName

--- a/Soongan/DesignSystem/Sources/Extension/Font+Soongan.swift
+++ b/Soongan/DesignSystem/Sources/Extension/Font+Soongan.swift
@@ -57,6 +57,10 @@ public extension Font {
         return ResourceFontFamily.Pretendard.medium.swiftUIFont(size: 24)
     }
     
+    static var medium20: Font {
+        return ResourceFontFamily.Pretendard.medium.swiftUIFont(size: 20)
+    }
+    
     static var medium16: Font {
         return ResourceFontFamily.Pretendard.medium.swiftUIFont(size: 16)
     }

--- a/Soongan/Feature/AllTimeContestFeature/Project.swift
+++ b/Soongan/Feature/AllTimeContestFeature/Project.swift
@@ -1,0 +1,28 @@
+import ProjectDescription
+
+let project = Project(
+    name: "AllTimeContestFeature",
+    packages: [
+      .package(
+        url: "https://github.com/pointfreeco/swift-composable-architecture.git",
+        from: "1.17.0"
+      ),
+    ],
+    targets: [
+        .target(
+            name: "AllTimeContestFeature",
+            destinations: .iOS,
+            product: .framework,
+            bundleId: "com.captures.AllTimeContestFeature.Soongan",
+            deploymentTargets: .iOS("17.0"),
+            infoPlist: .default,
+            sources: ["Sources/**"],
+            resources: [],
+            dependencies: [
+                .external(name: "ComposableArchitecture"),
+                .project(target: "DesignSystem", path: "../../DesignSystem"),
+                .project(target: "Shared", path: "../../Shared")
+            ]
+        )
+    ]
+)

--- a/Soongan/Feature/AllTimeContestFeature/Sources/Logic/AllTimeContestFeature.swift
+++ b/Soongan/Feature/AllTimeContestFeature/Sources/Logic/AllTimeContestFeature.swift
@@ -1,0 +1,125 @@
+//
+//  AllTimeContestFeature.swift
+//  AllTimeContestFeature
+//
+//  Created by ParkJunHyuk on 5/30/25.
+//
+
+import SwiftUI
+
+import DesignSystem
+import Shared
+
+import ComposableArchitecture
+
+@Reducer
+public struct AllTimeContestFeature {
+    
+    // MARK: - Path
+    
+    @Reducer(state: .equatable)
+    public enum AllTimeContestPath {
+        case detailContest(DetailContestFeature)
+    }
+    
+    // MARK: - State
+    
+    @ObservableState
+    public struct State: Equatable {
+        var path = StackState<AllTimeContestPath.State>()
+        
+        var allTimeContestListData = [AllTimeContestModel(title: "평화", backgroundImageURL: ""), AllTimeContestModel(title: "평화2", backgroundImageURL: ""), AllTimeContestModel(title: "평화3", backgroundImageURL: "")]
+        
+        // CustomTabBar 가시성
+        public var isTabBarVisible: Bool {
+            path.isEmpty
+        }
+        
+        public init() {}
+    }
+    
+    // MARK: - Init
+    
+    public init() {}
+    
+    // MARK: - Action
+    
+    public enum Action: BindableAction {
+        case path(StackActionOf<AllTimeContestPath>)
+        
+        case binding(BindingAction<State>)
+    
+        
+        case contestListTapped
+//        case presentSheet
+//        case chagneContestIndex
+//        case dismissContestSheet(Bool)
+//        case contestDetailImageTapped(String)
+//        case sortContestContentTapped
+    }
+    
+    // MARK: - Body
+    
+    public var body: some ReducerOf<Self> {
+        BindingReducer()
+        
+        Reduce { state, action in
+            switch action {
+                
+            case let .path(.element(id: _, action: action)):
+                switch action {
+                case .detailContest(.backButtonTapped):
+                    state.path.removeLast()
+                    return .none
+                default:
+                    return .none
+                }
+                
+            case .contestListTapped:
+                state.path.append(.detailContest(DetailContestFeature.State()))
+                return .none
+//            case let .path(.element(id: _, action: action)):
+//                switch action {
+//                case .contestDetail(.backButtonTapped):
+//                    state.path.removeLast()
+//                    return .none
+//                default:
+//                    return .none
+//                }
+//                
+//            case .binding(_):
+//                return .none
+//            
+//            case .contestDetailImageTapped:
+//                state.path.append(.contestDetail(ContestDetailFeature.State()))
+//                return .none
+//                
+//            case .sortContestContentTapped:
+//                return .none
+//                
+//            case .presentSheet:
+////                state.isContestSheetPresented = true
+//                return .none
+//                
+//            case .chagneContestIndex:
+//                let contest = state.contestOptions[state.selectedContestIndex]
+//                
+//                let splitResult = spiltIndexTitle(contest: contest)
+//                state.contestIndex = splitResult.index
+//                state.weekTopic = splitResult.contest
+//                
+//                state.isContestSheetPresented = false
+//                
+//                return .none
+//                
+//            case .dismissContestSheet:
+//                state.isContestSheetPresented = false
+//                return .none
+                
+            default:
+                return .none
+            }
+        }
+        .forEach(\.path, action: \.path)
+    }
+}

--- a/Soongan/Feature/AllTimeContestFeature/Sources/Logic/DetailContestFeature.swift
+++ b/Soongan/Feature/AllTimeContestFeature/Sources/Logic/DetailContestFeature.swift
@@ -1,0 +1,49 @@
+//
+//  DetailContestFeature.swift
+//  AllTimeContestFeature
+//
+//  Created by ParkJunHyuk on 6/12/25.
+//
+
+import SwiftUI
+
+import DesignSystem
+import Shared
+
+import ComposableArchitecture
+
+@Reducer
+public struct DetailContestFeature {
+    
+    // MARK: - State
+    
+    @ObservableState
+    public struct State: Equatable {
+        
+        
+    }
+    
+    // MARK: - Init
+    
+    public init() {}
+    
+    // MARK: - Action
+    
+    public enum Action: BindableAction {
+        case binding(BindingAction<State>)
+        
+        case backButtonTapped
+    }
+    
+    // MARK: - Body
+    
+    public var body: some ReducerOf<Self> {
+        Reduce { state, action in
+            switch action {
+     
+            default:
+                return .none
+            }
+        }
+    }
+}

--- a/Soongan/Feature/AllTimeContestFeature/Sources/Model/AllTimeContestModel.swift
+++ b/Soongan/Feature/AllTimeContestFeature/Sources/Model/AllTimeContestModel.swift
@@ -1,0 +1,13 @@
+//
+//  AllTimeContestModel.swift
+//  AllTimeContestFeature
+//
+//  Created by ParkJunHyuk on 6/12/25.
+//
+
+import Foundation
+
+struct AllTimeContestModel: Equatable, Hashable {
+    let title: String
+    let backgroundImageURL: String
+}

--- a/Soongan/Feature/AllTimeContestFeature/Sources/View/AllTimeContestView.swift
+++ b/Soongan/Feature/AllTimeContestFeature/Sources/View/AllTimeContestView.swift
@@ -1,0 +1,113 @@
+//
+//  AllTimeContestView.swift
+//  AllTimeContestFeature
+//
+//  Created by ParkJunHyuk on 6/12/25.
+//
+
+import SwiftUI
+import PhotosUI
+
+import DesignSystem
+
+import ComposableArchitecture
+
+public struct AllTimeContestView: View {
+
+    @Bindable var store: StoreOf<AllTimeContestFeature>
+    
+    // MARK: - Init
+    
+    public init(
+        store: StoreOf<AllTimeContestFeature>
+    ) {
+        self.store = store
+    }
+
+    // MARK: - Body
+    
+    public var body: some View {
+        NavigationStack(
+            path: $store.scope(state: \.path, action: \.path)
+        ) {
+            ZStack {
+                DesignSystem.Color.soonganBG.ignoresSafeArea()
+                
+                VStack(spacing: 0) {
+                    Text("역대 콘테스트")
+                        .font(.bold20)
+                        .foregroundStyle(Color.black100)
+                        .padding(.vertical, 28)
+                    
+                    if !(store.allTimeContestListData.isEmpty) {
+                        ScrollView {
+                            LazyVStack(spacing: 12) {
+                                ForEach(store.allTimeContestListData, id: \.self) { contestData in
+                                    contestListView(data: contestData) {
+                                        store.send(.contestListTapped)
+                                    }
+                                }
+                            }
+                        }
+                    } else {
+                        Spacer()
+                        
+                        VStack(spacing: 20) {
+                            Text("첫 회차가 진행되고 있습니다.")
+                            
+                            Text("회차가 끝나면 역대 콘테스트가 생깁니다.")
+                        }
+                        .font(.bold20)
+                        .foregroundStyle(Color.black100)
+                        
+                        Spacer(minLength: 350)
+                    }
+                }
+            }
+            .toolbar(.hidden, for: .tabBar)
+        } destination: { store in
+            switch store.case {
+            case .detailContest(let store):
+                DetailContestView(store: store)
+            }
+        }
+    }
+}
+
+// MARK: - Private View Extension
+
+private extension AllTimeContestView {
+    func contestListView(data: AllTimeContestModel, onTap: @escaping () -> Void) -> some View {
+        ZStack {
+            Image.dumy5
+                .resizable()
+                .aspectRatio(contentMode: .fill)
+                .frame(height: 126)
+                .clipped()
+            
+            // 블러 처리용 배경 뷰
+            Rectangle()
+                .fill(Color.black100.opacity(0.5))
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            
+            Text(data.title)
+                .font(.bold20)
+                .foregroundStyle(Color.white)
+        }
+        .padding(.horizontal, 16)
+        .onTapGesture {
+            onTap()
+        }
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    AllTimeContestView(
+        store: Store(initialState:
+            AllTimeContestFeature.State()) {
+                AllTimeContestFeature()
+        }
+    )
+}

--- a/Soongan/Feature/AllTimeContestFeature/Sources/View/DetailContestView.swift
+++ b/Soongan/Feature/AllTimeContestFeature/Sources/View/DetailContestView.swift
@@ -1,0 +1,161 @@
+//
+//  DetailContestView.swift
+//  AllTimeContestFeature
+//
+//  Created by ParkJunHyuk on 6/12/25.
+//
+
+import SwiftUI
+
+import DesignSystem
+import Shared
+import Resource
+
+import ComposableArchitecture
+
+struct DetailContestView: View {
+    
+    let imageModels1 = [
+        ContestImageModel(imageName: "dumy2", contestImage: ResourceAsset.Image.dumy2.swiftUIImage),
+        ContestImageModel(imageName: "dumy1", contestImage: ResourceAsset.Image.dumy1.swiftUIImage)
+    ]
+    
+    let imageModels2 = [
+        ContestImageModel(imageName: "dumy7", contestImage: ResourceAsset.Image.dumy7.swiftUIImage),
+        ContestImageModel(imageName: "dumy6", contestImage: ResourceAsset.Image.dumy6.swiftUIImage)
+    ]
+    
+    @Bindable var store: StoreOf<DetailContestFeature>
+    
+    // MARK: - Init
+    
+    public init(
+        store: StoreOf<DetailContestFeature>
+    ) {
+        self.store = store
+    }
+    
+    // MARK: - Body
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            topBackButtonSection()
+            
+            ScrollView {
+                VStack(spacing: 0) {
+                    
+                    Image.dumy6
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(width: 360)
+                        .padding(.top, 27)
+                    
+                    contestTitleSection()
+                        .padding(.top, 40)
+                        .padding(.bottom, 92)
+                    
+                    HStack(alignment: .top) {
+                        LazyVStack(spacing: 8) {
+                            ForEach(imageModels1) { model in
+                                model.contestImage
+                                    .resizable()
+                                    .aspectRatio(contentMode: .fit)
+                                    .onAppear {
+                                        print("1열", model.imageName)
+                                    }
+                                    .onTapGesture {
+                                        //                                    onImageTap(model) // ✅ 콜백 호출
+                                    }
+                            }
+                        }
+                        
+                        LazyVStack(spacing: 8) {
+                            ForEach(imageModels2) { model in
+                                model.contestImage
+                                    .resizable()
+                                    .aspectRatio(contentMode: .fit)
+                                    .onAppear {
+                                        print("2열", model.imageName)
+                                    }
+                                    .onTapGesture {
+                                        //                                    onImageTap(model) // ✅ 콜백 호출
+                                    }
+                            }
+                        }
+                    }
+                    .padding(.horizontal, 8)
+                }
+                .padding(.bottom, 70)
+                
+                Button(action: {
+                    
+                }) {
+                    Text("참여작품 보러 가기👀")
+                        .font(.medium20)
+                        .foregroundColor(DesignSystem.Color.black100)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 18)
+                        .background(DesignSystem.Color.primary)
+                        .cornerRadius(30)
+                }
+                .padding(.horizontal, 12)
+                .padding(.bottom, 48)
+            }
+            .background(DesignSystem.Color.soonganBG)
+        }
+        .background(InteractivePopGestureEnabler())
+        .navigationBarBackButtonHidden(true)
+    }
+    
+    func topBackButtonSection() -> some View {
+        HStack {
+            Button {
+                store.send(.backButtonTapped)
+            } label: {
+                HStack(spacing: 0) {
+                    Image.arrowBack
+                        .padding(.trailing, 5)
+                }
+            }
+            .padding(.top, 16)
+            .padding(.leading, 25)
+            
+            Spacer()
+        }
+        .frame(maxWidth: .infinity)
+        .frame(height: 52)
+        .background(DesignSystem.Color.soonganBG)
+    }
+    
+    func contestTitleSection() -> some View {
+        VStack(spacing: 0) {
+            Text("평화 (1회차)")
+                .font(.semibold20)
+                .foregroundColor(DesignSystem.Color.black100)
+                .padding(.bottom, 20)
+            
+            Text("2025.01.17 - 2025.01.20")
+                .font(.semibold14)
+                .foregroundColor(DesignSystem.Color.black100)
+                .padding(.bottom, 8)
+            
+            
+            Text("총 참여작품 수 : 30")
+                .font(.semibold14)
+                .foregroundColor(DesignSystem.Color.black100)
+        }
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    NavigationStack {
+        DetailContestView(
+            store: Store(initialState:
+                            DetailContestFeature.State()) {
+                                DetailContestFeature()
+                            }
+        )
+    }
+}

--- a/Soongan/Project.swift
+++ b/Soongan/Project.swift
@@ -35,6 +35,7 @@ let project = Project(
                 .project(target: "AuthFeature", path: "Feature/AuthFeature"),
                 .project(target: "HomeFeature", path: "Feature/HomeFeature"),
                 .project(target: "ContestFeature", path: "Feature/ContestFeature"),
+                .project(target: "AllTimeContestFeature", path: "Feature/AllTimeContestFeature"),
                 .project(target: "MypageFeature", path: "Feature/MypageFeature")
             ]
         ),

--- a/Soongan/Soongan/Sources/MainTabFeature.swift
+++ b/Soongan/Soongan/Sources/MainTabFeature.swift
@@ -10,6 +10,7 @@ import SwiftUI
 
 import HomeFeature
 import ContestFeature
+import AllTimeContestFeature
 import MypageFeature
 import Shared
 
@@ -25,10 +26,11 @@ public struct MainTabFeature {
         var selectedTab: Tab = .home
         var home: HomeFeature.State = .init(weekTopic: "평화", startPeriod: "2024.05.10 09:00:00", endPeriod: "2024.05.16 23:59:59")
         var contest: ContestFeature.State = .init()
+        var allTimeContest: AllTimeContestFeature.State = .init()
         var mypage: MypageFeature.State = .init()
         
         public enum Tab {
-           case home, contest, myPage
+           case home, contest, allTimeContest, myPage
         }
         
         var isTabBarVisible: Bool {
@@ -37,6 +39,8 @@ public struct MainTabFeature {
                 return home.isTabBarVisible
             case .contest:
                 return contest.isTabBarVisible
+            case .allTimeContest:
+                return allTimeContest.isTabBarVisible
             case .myPage:
                 return mypage.isTabBarVisible
             }
@@ -53,6 +57,7 @@ public struct MainTabFeature {
         case selectTab(State.Tab)
         case home(HomeFeature.Action)
         case contest(ContestFeature.Action)
+        case allTimeContest(AllTimeContestFeature.Action)
         case mypage(MypageFeature.Action)
     }
     
@@ -67,6 +72,10 @@ public struct MainTabFeature {
             ContestFeature()
         }
         
+        Scope(state: \.allTimeContest, action: \.allTimeContest) {
+            AllTimeContestFeature()
+        }
+        
         Scope(state: \.mypage, action: \.mypage) {
             MypageFeature()
         }
@@ -79,6 +88,8 @@ public struct MainTabFeature {
             case .home:
                 return .none
             case .contest:
+                return .none
+            case .allTimeContest:
                 return .none
             case .mypage:
                 return .none

--- a/Soongan/Soongan/Sources/MainTabView.swift
+++ b/Soongan/Soongan/Sources/MainTabView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 
 import HomeFeature
 import ContestFeature
+import AllTimeContestFeature
 import MypageFeature
 
 import ComposableArchitecture
@@ -31,12 +32,14 @@ public struct MainTabView: View {
     public var body: some View {
         ZStack(alignment: .bottom) {
             TabView(selection: $store.selectedTab.sending(\.selectTab)) {
-                
                 HomeView(store: store.scope(state: \.home, action: \.home))
                     .tag(MainTabFeature.State.Tab.home)
                 
                 ContestView(store: store.scope(state: \.contest, action: \.contest))
                     .tag(MainTabFeature.State.Tab.contest)
+                
+                AllTimeContestView(store: store.scope(state: \.allTimeContest, action: \.allTimeContest))
+                    .tag(MainTabFeature.State.Tab.allTimeContest)
                 
                 MypageView(store: store.scope(state: \.mypage, action: \.mypage))
                     .tag(MainTabFeature.State.Tab.myPage)
@@ -51,14 +54,11 @@ public struct MainTabView: View {
             }
             .animation(.easeInOut(duration: 0.05), value: store.isTabBarVisible) // 더 빠른 반응
         }
-
         .ignoresSafeArea(edges: .bottom)
     }
     
     var customTabBar: some View {
         HStack(spacing: 0) {
-            Spacer()
-            
             Button(action: {
                 store.send(.selectTab(.home))
             }) {
@@ -76,13 +76,20 @@ public struct MainTabView: View {
             Spacer()
             
             Button(action: {
+                store.send(.selectTab(.allTimeContest))
+            }) {
+                store.selectedTab == .allTimeContest ? Image.selectAwardIcon : Image.notSelectAwardIcon
+            }
+            
+            Spacer()
+            
+            Button(action: {
                 store.send(.selectTab(.myPage))
             }) {
                 store.selectedTab == .myPage ? Image.selectMypageIcon : Image.notSelectMypageIcon
             }
-            
-            Spacer()
         }
+        .padding(.horizontal, 40)
         .padding(.bottom, 43)
         .padding(.top, 16)
         .frame(height: 83)


### PR DESCRIPTION
## 📟 관련 이슈
- Resolved: #11

<br>

## 👷 작업한 내용
<!-- 작업한 내용을 적어주세요. -->
- 역대 콘테스트를 보여주는 `AllTimeContestFeature` 모듈 구현
- 해당 회차 콘테스트의 사진을 보여주는 `DetailContestView` 구현

<br>

## 📸 스크린샷
|기능|역대 콘테스트|
|:--:|:--:|
|GIF|<img src = "https://github.com/user-attachments/assets/bbf8dc09-2d4e-4ce7-9ede-cbea7c04f3a5" width ="250">|


<br>

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
