### PR TITLE
[Feat] #13 - 기본 네트워크 레이어 구성 및 UI, 데이터 바인딩 적용

### DIFF
--- a/Soongan/Core/CoreAppleLogin/Project.swift
+++ b/Soongan/Core/CoreAppleLogin/Project.swift
@@ -1,0 +1,18 @@
+import ProjectDescription
+
+let project = Project(
+    name: "CoreAppleLogin",
+    targets: [
+        .target(
+            name: "CoreAppleLogin",
+            destinations: .iOS,
+            product: .staticFramework,
+            bundleId: "com.captures.CoreAppleLogin.Soongan",
+            deploymentTargets: .iOS("17.0"),
+            infoPlist: .default,
+            sources: ["Sources/**"],
+            resources: [],
+            dependencies: []
+        )
+    ]
+)

--- a/Soongan/Core/CoreAppleLogin/Sources/AppleLoginError.swift
+++ b/Soongan/Core/CoreAppleLogin/Sources/AppleLoginError.swift
@@ -1,0 +1,12 @@
+//
+//  AppleLoginError.swift
+//  CoreAppleLogin
+//
+//  Created by ParkJunHyuk on 5/25/25.
+//
+
+import Foundation
+
+public enum AppleLoginError: Error {
+    case noCredential
+}

--- a/Soongan/Core/CoreAppleLogin/Sources/AppleLoginService.swift
+++ b/Soongan/Core/CoreAppleLogin/Sources/AppleLoginService.swift
@@ -1,0 +1,62 @@
+//
+//  AppleLoginService.swift
+//  Core
+//
+//  Created by ParkJunHyuk on 5/25/25.
+//
+
+import AuthenticationServices
+
+public final class AppleLoginService: NSObject, AppleLoginServiceProtocol {
+    public static let shared = AppleLoginService()
+    
+    private override init() {}
+    
+    private var continuation: CheckedContinuation<String, Error>?
+
+    public func login() async throws -> (String) {
+       return try await withCheckedThrowingContinuation { continuation in
+           self.continuation = continuation
+           let provider = ASAuthorizationAppleIDProvider()
+           let request = provider.createRequest()
+           request.requestedScopes = [.fullName]
+           let controller = ASAuthorizationController(authorizationRequests: [request])
+           controller.delegate = self
+           controller.presentationContextProvider = self
+           controller.performRequests()
+       }
+   }
+}
+
+extension AppleLoginService: ASAuthorizationControllerDelegate {
+    public func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
+        
+        guard let credential = authorization.credential as? ASAuthorizationAppleIDCredential else {
+            continuation?.resume(throwing: AppleLoginError.noCredential)
+            return
+        }
+        
+        guard let identityTokenData = credential.identityToken,
+              let identityToken = String(data: identityTokenData, encoding: .utf8) else {
+            continuation?.resume(throwing: AppleLoginError.noCredential)
+            return
+        }
+
+        print("애플로그인 결과 반환", identityToken)
+
+        continuation?.resume(returning: identityToken)
+   }
+
+   public func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
+       continuation?.resume(throwing: error)
+   }
+}
+
+extension AppleLoginService: ASAuthorizationControllerPresentationContextProviding {
+   public func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
+       return UIApplication.shared.connectedScenes
+           .compactMap { $0 as? UIWindowScene }
+           .flatMap { $0.windows }
+           .first { $0.isKeyWindow } ?? UIWindow()
+   }
+}

--- a/Soongan/Core/CoreAppleLogin/Sources/AppleLoginService.swift
+++ b/Soongan/Core/CoreAppleLogin/Sources/AppleLoginService.swift
@@ -19,7 +19,8 @@ public final class AppleLoginService: NSObject, AppleLoginServiceProtocol {
            self.continuation = continuation
            let provider = ASAuthorizationAppleIDProvider()
            let request = provider.createRequest()
-           request.requestedScopes = [.fullName]
+           request.requestedScopes = []
+           
            let controller = ASAuthorizationController(authorizationRequests: [request])
            controller.delegate = self
            controller.presentationContextProvider = self

--- a/Soongan/Core/CoreAppleLogin/Sources/AppleLoginServiceProtocol.swift
+++ b/Soongan/Core/CoreAppleLogin/Sources/AppleLoginServiceProtocol.swift
@@ -1,0 +1,12 @@
+//
+//  AppleLoginServiceProtocol.swift
+//  CoreAppleLogin
+//
+//  Created by ParkJunHyuk on 6/17/25.
+//
+
+import Foundation
+
+public protocol AppleLoginServiceProtocol {
+    func login() async throws -> String
+}

--- a/Soongan/Core/CoreKakaoLogin/Project.swift
+++ b/Soongan/Core/CoreKakaoLogin/Project.swift
@@ -1,0 +1,22 @@
+import ProjectDescription
+
+let project = Project(
+    name: "CoreKakaoLogin",
+    targets: [
+        .target(
+            name: "CoreKakaoLogin",
+            destinations: .iOS,
+            product: .staticFramework,
+            bundleId: "com.captures.CoreKakaoLogin.Soongan",
+            deploymentTargets: .iOS("17.0"),
+            infoPlist: .default,
+            sources: ["Sources/**"],
+            resources: [],
+            dependencies: [
+                .external(name: "KakaoSDKCommon"),
+                .external(name: "KakaoSDKAuth"),
+                .external(name: "KakaoSDKUser")
+            ]
+        )
+    ]
+)

--- a/Soongan/Core/CoreKakaoLogin/Sources/KakaoLoginError.swift
+++ b/Soongan/Core/CoreKakaoLogin/Sources/KakaoLoginError.swift
@@ -1,0 +1,14 @@
+//
+//  KakaoLoginError.swift
+//  CoreKakaoLogin
+//
+//  Created by ParkJunHyuk on 5/26/25.
+//
+
+import Foundation
+
+public enum KakaoLoginError: Error {
+    case tokenIssueFailed
+    case userInfoFailed
+    case unknown
+}

--- a/Soongan/Core/CoreKakaoLogin/Sources/KakaoLoginService.swift
+++ b/Soongan/Core/CoreKakaoLogin/Sources/KakaoLoginService.swift
@@ -1,0 +1,69 @@
+//
+//  KakaoLoginService.swift
+//  Core
+//
+//  Created by ParkJunHyuk on 5/26/25.
+//
+
+import AuthenticationServices
+import KakaoSDKAuth
+import KakaoSDKUser
+
+public final class KakaoLoginService: NSObject, KakaoLoginServiceProtocol {
+    public static let shared = KakaoLoginService()
+    
+    private override init() {}
+
+    public func login() async throws -> String {
+        let oauthToken = try await loginWithKakaoAppOrWeb()
+        
+        return oauthToken.accessToken
+    }
+}
+
+private extension KakaoLoginService {
+    @MainActor
+    func loginWithKakaoAppOrWeb() async throws -> OAuthToken {
+        try await withCheckedThrowingContinuation { continuation in
+            
+            print("✅ KakaoTalk 설치 여부: \(UserApi.isKakaoTalkLoginAvailable())")
+            // 앱으로 로그인 시도
+            if UserApi.isKakaoTalkLoginAvailable() {
+                UserApi.shared.loginWithKakaoTalk { token, error in
+                    if let token = token {
+                        continuation.resume(returning: token)
+                    } else if let error = error {
+                        continuation.resume(throwing: error)
+                    } else {
+                        continuation.resume(throwing: KakaoLoginError.tokenIssueFailed)
+                    }
+                }
+            } else {
+                // 웹으로 로그인
+                UserApi.shared.loginWithKakaoAccount { token, error in
+                    if let token = token {
+                        continuation.resume(returning: token)
+                    } else if let error = error {
+                        continuation.resume(throwing: error)
+                    } else {
+                        continuation.resume(throwing: KakaoLoginError.tokenIssueFailed)
+                    }
+                }
+            }
+        }
+    }
+
+    func fetchUserInfo() async throws -> User {
+        try await withCheckedThrowingContinuation { continuation in
+            UserApi.shared.me { user, error in
+                if let user = user {
+                    continuation.resume(returning: user)
+                } else if let error = error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume(throwing: KakaoLoginError.userInfoFailed)
+                }
+            }
+        }
+    }
+}

--- a/Soongan/Core/CoreKakaoLogin/Sources/KakaoLoginServiceProtocol.swift
+++ b/Soongan/Core/CoreKakaoLogin/Sources/KakaoLoginServiceProtocol.swift
@@ -1,0 +1,12 @@
+//
+//  KakaoLoginServiceProtocol.swift
+//  CoreKakaoLogin
+//
+//  Created by ParkJunHyuk on 6/17/25.
+//
+
+import Foundation
+
+public protocol KakaoLoginServiceProtocol {
+    func login() async throws -> String
+}

--- a/Soongan/Core/CoreKeyChain/Project.swift
+++ b/Soongan/Core/CoreKeyChain/Project.swift
@@ -1,0 +1,18 @@
+import ProjectDescription
+
+let project = Project(
+    name: "CoreKeyChain",
+    targets: [
+        .target(
+            name: "CoreKeyChain",
+            destinations: .iOS,
+            product: .staticFramework,
+            bundleId: "com.captures.CoreKeyChain.Soongan",
+            deploymentTargets: .iOS("17.0"),
+            infoPlist: .default,
+            sources: ["Sources/**"],
+            resources: [],
+            dependencies: []
+        )
+    ]
+)

--- a/Soongan/Core/CoreKeyChain/Sources/Config.swift
+++ b/Soongan/Core/CoreKeyChain/Sources/Config.swift
@@ -1,0 +1,48 @@
+//
+//  Config.swift
+//  CoreKeyChain
+//
+//  Created by ParkJunHyuk on 6/17/25.
+//
+
+import Foundation
+
+public enum Config {
+    enum Keys {
+        enum Keychain: String {
+            case accessToken = "ACCESS_TOKEN_KEY"
+            case refreshToken = "REFRESH_TOKEN_KEY"
+            case fcmToken = "FCM_TOKEN_KEY"
+        }
+    }
+    
+    private static let infoDictionary: [String: Any] = {
+        guard let dict = Bundle.main.infoDictionary else {
+            fatalError("plist cannot found !!!")
+        }
+        return dict
+    }()
+}
+
+extension Config {
+    static let accessTokenKey: String = {
+        guard let key = Config.infoDictionary[Keys.Keychain.accessToken.rawValue] as? String else {
+            fatalError("⛔️accessToken is not set in plist for this configuration⛔️")
+        }
+        return key
+    }()
+    
+    static let refreshTokenKey: String = {
+        guard let key = Config.infoDictionary[Keys.Keychain.refreshToken.rawValue] as? String else {
+            fatalError("⛔️refreshToken is not set in plist for this configuration⛔️")
+        }
+        return key
+    }()
+    
+    static let fcmTokenKey: String = {
+        guard let key = Config.infoDictionary[Keys.Keychain.fcmToken.rawValue] as? String else {
+            fatalError("⛔️fcmToken is not set in plist for this configuration⛔️")
+        }
+        return key
+    }()
+}

--- a/Soongan/Core/CoreKeyChain/Sources/KeychainManager.swift
+++ b/Soongan/Core/CoreKeyChain/Sources/KeychainManager.swift
@@ -1,0 +1,189 @@
+//
+//  KeychainManager.swift
+//  Core
+//
+//  Created by ParkJunHyuk on 5/23/25.
+//
+
+import Foundation
+
+// MARK: - KeychainKey
+
+/// 키체인에 저장될 데이터의 키 값을 정의하는 열거형
+///
+/// 각 case는 저장할 데이터의 종류를 나타내며, Info.plist에 정의된 실제 키 값과 매핑됩니다.
+/// - Note: value 프로퍼티를 통해 Info.plist에 정의된 실제 키 값을 가져옵니다.
+///
+/// ```swift
+/// // KeychainKey 사용 예시
+/// let accessTokenKey = KeychainKey.accessToken
+/// let refreshTokenKey = KeychainKey.refreshToken
+///
+/// // 실제 키 값 얻기
+/// let actualKey = KeychainKey.accessToken.value
+/// ```
+public enum KeychainKey: String {
+    /// 액세스 토큰을 저장하기 위한 키
+    case accessToken
+    /// 리프레시 토큰을 저장하기 위한 키
+    case refreshToken
+    
+    case fcmToken
+    
+    /// Info.plist에서 정의된 실제 키체인 키 값을 반환합니다.
+        /// - Returns: Info.plist에 정의된 실제 키 문자열
+    var value: String {
+        switch self {
+        case .accessToken:
+            return Config.accessTokenKey
+        case .refreshToken:
+            return Config.refreshTokenKey
+        case .fcmToken:
+            return Config.fcmTokenKey
+        }
+    }
+}
+
+// MARK: - KeychainManager
+
+/// 키체인 데이터를 안전하게 관리하기 위한 매니저 클래스
+///
+/// 이 클래스는 싱글톤 패턴을 사용하여 키체인 접근을 한 곳에서 관리합니다.
+/// 토큰과 같은 민감한 데이터를 안전하게 저장, 조회, 삭제할 수 있는 메서드를 제공합니다.
+///
+/// ## 일반적인 사용 예시:
+/// ```swift
+/// // 토큰 저장
+/// KeychainManager.shared.save(key: .accessToken, value: "eyJhbGciOiJ...")
+///
+/// // 토큰 조회
+/// if let token = KeychainManager.shared.load(key: .accessToken) {
+///     // 토큰 사용
+///     print("Access Token: \(token)")
+/// }
+///
+/// // 토큰 삭제
+/// KeychainManager.shared.delete(key: .accessToken)
+///
+/// // 모든 토큰 삭제 (로그아웃, 회원탈퇴 시)
+/// KeychainManager.shared.clearTokens()
+/// ```
+public final class KeychainManager {
+    /// 싱글톤 인스턴스
+    public static let shared = KeychainManager()
+    
+    /// 외부에서의 인스턴스 생성을 방지하기 위한 private 생성자
+    public init() {}
+    
+    /// 키체인에 데이터를 저장하는 메서드
+    /// - Parameters:
+    ///   - key: 저장할 데이터의 키 (KeychainKey 타입)
+    ///   - value: 저장할 값 (String 타입)
+    /// - Note: 이미 같은 키로 저장된 데이터가 있다면 덮어씌웁니다.
+    public func save(key: KeychainKey, value: String) {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: key.rawValue,
+            kSecValueData as String: value.data(using: .utf8) as Any
+        ]
+        
+        // 기존 데이터 삭제 후 새로운 데이터 저장
+        SecItemDelete(query as CFDictionary)
+        SecItemAdd(query as CFDictionary, nil)
+        
+        print("📥 KeyChain - \(key) 저장 완료")
+    }
+    
+    /// 키체인에서 데이터를 조회하는 메서드
+    /// - Parameter key: 조회할 데이터의 키 (KeychainKey 타입)
+    /// - Returns: 저장된 문자열 값, 데이터가 없거나 오류 발생 시 nil 반환
+    public func load(key: KeychainKey) -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: key.rawValue,
+            kSecReturnData as String: kCFBooleanTrue!,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+        
+        var dataTypeRef: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &dataTypeRef)
+        
+        if status == errSecSuccess {
+            if let data = dataTypeRef as? Data {
+                
+                print("📤 KeyChain - \(key) 불러오기 완료")
+                return String(data: data, encoding: .utf8)
+            }
+        }
+        return nil
+    }
+    
+    /// 키체인에서 특정 키의 데이터를 삭제하는 메서드
+    /// - Parameter key: 삭제할 데이터의 키 (KeychainKey 타입)
+    public func delete(key: KeychainKey) {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: key.rawValue
+        ]
+        
+        SecItemDelete(query as CFDictionary)
+        
+        print("📥 KeyChain - \(key) 삭제 완료")
+    }
+    
+    /// 모든 토큰 관련 데이터를 키체인에서 삭제하는 메서드
+    /// - Note: 로그아웃 시 호출하여 모든 인증 관련 데이터를 삭제합니다.
+    public func clearTokens() {
+        delete(key: .accessToken)
+        delete(key: .refreshToken)
+    }
+}
+
+extension KeychainManager {
+    // 클래스 인스턴스를 저장하는 함수
+    func saveData<T: Codable>(key: KeychainKey, value: T) {
+        do {
+            let data = try JSONEncoder().encode(value) // Codable 클래스 인코딩
+            let query: [String: Any] = [
+                kSecClass as String: kSecClassGenericPassword,
+                kSecAttrAccount as String: key.rawValue,
+                kSecValueData as String: data
+            ]
+            
+            SecItemDelete(query as CFDictionary) // 기존 데이터 삭제
+            SecItemAdd(query as CFDictionary, nil) // 새 데이터 저장
+            print("📥 Keychain - \(key) 저장 완료")
+            
+        } catch {
+            print("Keychain 저장 오류: \(error)")
+        }
+    }
+    
+    // 저장된 클래스 인스턴스를 불러오는 함수
+    func loadData<T: Codable>(key: KeychainKey, type: T.Type) -> T? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: key.rawValue,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+        
+        var dataTypeRef: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &dataTypeRef)
+        
+        guard status == errSecSuccess, let data = dataTypeRef as? Data else {
+            print("Keychain에서 \(key) 불러오기 실패")
+            return nil
+        }
+        
+        do {
+            let decodedObject = try JSONDecoder().decode(T.self, from: data)
+            print("Keychain에서 \(key) 불러오기 성공")
+            return decodedObject
+        } catch {
+            print("Keychain 디코딩 오류: \(error)")
+            return nil
+        }
+    }
+}
+

--- a/Soongan/Core/CoreNetwork/Project.swift
+++ b/Soongan/Core/CoreNetwork/Project.swift
@@ -1,0 +1,21 @@
+import ProjectDescription
+
+let project = Project(
+    name: "CoreNetwork",
+    targets: [
+        .target(
+            name: "CoreNetwork",
+            destinations: .iOS,
+            product: .framework,
+            bundleId: "com.captures.CoreNetwork.Soongan",
+            deploymentTargets: .iOS("17.0"),
+            infoPlist: .default,
+            sources: ["Sources/**"],
+            resources: [],
+            dependencies: [
+                .external(name: "Alamofire"),
+                .project(target: "CoreKeyChain", path: "../CoreKeyChain")
+            ]
+        )
+    ]
+)

--- a/Soongan/Core/CoreNetwork/Sources/Auth/AuthEndpoint.swift
+++ b/Soongan/Core/CoreNetwork/Sources/Auth/AuthEndpoint.swift
@@ -1,0 +1,65 @@
+//
+//  AuthEndpoint.swift
+//  CoreNetwork
+//
+//  Created by ParkJunHyuk on 6/16/25.
+//
+
+import Alamofire
+
+public enum AuthEndpoint {
+    case postLogin(LoginRequestDTO)
+    case postLogout
+    case patchRefresh(RefreshRequestDTO)
+    case postWithdraw
+}
+
+extension AuthEndpoint: APIEndpoint {
+    public var basePath: BasePath {
+        return .auth
+    }
+    
+    public var path: String {
+        switch self {
+        case .postLogin:
+            return basePath.rawValue + "/login"
+        case .postLogout:
+            return basePath.rawValue + "/logout"
+        case .patchRefresh:
+            return basePath.rawValue + "/refresh"
+        case .postWithdraw:
+            return basePath.rawValue + "/withdraw"
+        }
+    }
+    
+    public var method: Alamofire.HTTPMethod {
+        switch self {
+        case .postLogin, .postLogout, .postWithdraw:
+            return .post
+        case .patchRefresh:
+            return .patch
+        }
+    }
+    
+    public var headerType: HeaderType {
+        switch self {
+        case .postLogin:
+            return .userAgentHeader("IOS")
+        case .patchRefresh:
+            return .defaultHeader
+        case .postLogout, .postWithdraw:
+            return .accessTokenHeader
+        }
+    }
+    
+    public var parameters: (any Encodable)? {
+        switch self {
+        case .postLogin(let dto):
+            return dto
+        case .patchRefresh(let dto):
+            return dto
+        default:
+            return nil
+        }
+    }
+}

--- a/Soongan/Core/CoreNetwork/Sources/Auth/AuthEndpoint.swift
+++ b/Soongan/Core/CoreNetwork/Sources/Auth/AuthEndpoint.swift
@@ -6,6 +6,7 @@
 //
 
 import Alamofire
+import Foundation
 
 public enum AuthEndpoint {
     case postLogin(LoginRequestDTO)
@@ -44,7 +45,7 @@ extension AuthEndpoint: APIEndpoint {
     public var headerType: HeaderType {
         switch self {
         case .postLogin:
-            return .userAgentHeader("IOS")
+            return .userAgentHeader
         case .patchRefresh:
             return .defaultHeader
         case .postLogout, .postWithdraw:
@@ -52,7 +53,11 @@ extension AuthEndpoint: APIEndpoint {
         }
     }
     
-    public var parameters: (any Encodable)? {
+    public var queryParameters: [URLQueryItem]? {
+        return nil
+    }
+    
+    public var body: (any Encodable)? {
         switch self {
         case .postLogin(let dto):
             return dto

--- a/Soongan/Core/CoreNetwork/Sources/Auth/DTO/Request/LoginRequestDTO.swift
+++ b/Soongan/Core/CoreNetwork/Sources/Auth/DTO/Request/LoginRequestDTO.swift
@@ -1,0 +1,20 @@
+//
+//  LoginRequestDTO.swift
+//  CoreNetwork
+//
+//  Created by ParkJunHyuk on 6/16/25.
+//
+
+import Foundation
+
+public struct LoginRequestDTO: Encodable {
+    let provider: String
+    let idToken: String
+    let fcmToken: String
+    
+    public init(provider: String, idToken: String, fcmToken: String) {
+        self.provider = provider
+        self.idToken = idToken
+        self.fcmToken = fcmToken
+    }
+}

--- a/Soongan/Core/CoreNetwork/Sources/Auth/DTO/Request/RefreshRequestDTO.swift
+++ b/Soongan/Core/CoreNetwork/Sources/Auth/DTO/Request/RefreshRequestDTO.swift
@@ -1,0 +1,13 @@
+//
+//  RefreshRequestDTO.swift
+//  CoreNetwork
+//
+//  Created by ParkJunHyuk on 6/16/25.
+//
+
+import Foundation
+
+public struct RefreshRequestDTO: Encodable {
+    let accessToken: String
+    let refreshToken: String
+}

--- a/Soongan/Core/CoreNetwork/Sources/Auth/DTO/Response/AuthedResponseDTO.swift
+++ b/Soongan/Core/CoreNetwork/Sources/Auth/DTO/Response/AuthedResponseDTO.swift
@@ -1,0 +1,18 @@
+//
+//  AuthedResponseDTO.swift
+//  CoreNetwork
+//
+//  Created by ParkJunHyuk on 6/16/25.
+//
+
+import Foundation
+
+public struct AuthedResponseDTO: Decodable {
+    let accessToken: String
+    let refreshToken: String
+    
+    public init(accessToken: String, refreshToken: String) {
+        self.accessToken = accessToken
+        self.refreshToken = refreshToken
+    }
+}

--- a/Soongan/Core/CoreNetwork/Sources/Auth/DTO/Response/AuthedResponseDTO.swift
+++ b/Soongan/Core/CoreNetwork/Sources/Auth/DTO/Response/AuthedResponseDTO.swift
@@ -8,8 +8,8 @@
 import Foundation
 
 public struct AuthedResponseDTO: Decodable {
-    let accessToken: String
-    let refreshToken: String
+    public let accessToken: String
+    public let refreshToken: String
     
     public init(accessToken: String, refreshToken: String) {
         self.accessToken = accessToken

--- a/Soongan/Core/CoreNetwork/Sources/Base/APIResponse.swift
+++ b/Soongan/Core/CoreNetwork/Sources/Base/APIResponse.swift
@@ -1,0 +1,20 @@
+//
+//  APIResponse.swift
+//  CoreNetwork
+//
+//  Created by ParkJunHyuk on 6/17/25.
+//
+
+import Foundation
+
+public struct APIResponse<T: Decodable>: Decodable {
+    let status: Int
+    let message: String
+    let responseData: T
+}
+
+public struct APIErrorResponse: Decodable {
+    let status: Int
+    let message: String
+    let detailMessage: String
+}

--- a/Soongan/Core/CoreNetwork/Sources/Base/APIResponse.swift
+++ b/Soongan/Core/CoreNetwork/Sources/Base/APIResponse.swift
@@ -8,13 +8,14 @@
 import Foundation
 
 public struct APIResponse<T: Decodable>: Decodable {
-    let status: Int
+    let statusCode: Int
     let message: String
     let responseData: T
+    let detailMessage: String?
 }
 
 public struct APIErrorResponse: Decodable {
-    let status: Int
+    let statusCode: Int
     let message: String
     let detailMessage: String
 }

--- a/Soongan/Core/CoreNetwork/Sources/Base/AuthInterceptor.swift
+++ b/Soongan/Core/CoreNetwork/Sources/Base/AuthInterceptor.swift
@@ -19,8 +19,12 @@ final class AuthInterceptor: RequestInterceptor {
         
         var urlRequest = urlRequest
         
-        if let token = KeychainManager.shared.load(key: .accessToken) {
-            urlRequest.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        if let headerType = urlRequest.value(forHTTPHeaderField: "X-Header-Type") {
+            if headerType == "accessToken" {
+                if let token = KeychainManager.shared.load(key: .accessToken) {
+                    urlRequest.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+                }
+            }
         }
         
         completion(.success(urlRequest))
@@ -65,21 +69,8 @@ private extension AuthInterceptor {
         }
         
         let endpoint = AuthEndpoint.patchRefresh(RefreshRequestDTO(accessToken: accessToken, refreshToken: refreshToken))
-        
-        let parameters = try? endpoint.parameters.flatMap { encodable -> [String: Any]? in
-            let data = try JSONEncoder().encode(encodable)
-            return try JSONSerialization.jsonObject(with: data) as? [String: Any]
-        }
-        
-        let session = Session.default
-        
-        let dataTask = session.request(
-               endpoint.baseURL.appendingPathComponent(endpoint.path),
-               method: endpoint.method,
-               parameters: parameters,
-               encoding: endpoint.method == .get ? URLEncoding.default : JSONEncoding.default,
-               headers: endpoint.headers
-           )
+
+        let dataTask = Session.default.request(APIRouter(endpoint: endpoint))
            .validate(statusCode: 200..<300)
            .serializingDecodable(APIResponse<AuthedResponseDTO>.self)
         

--- a/Soongan/Core/CoreNetwork/Sources/Base/AuthInterceptor.swift
+++ b/Soongan/Core/CoreNetwork/Sources/Base/AuthInterceptor.swift
@@ -1,0 +1,105 @@
+//
+//  AuthInterceptor.swift
+//  CoreNetwork
+//
+//  Created by ParkJunHyuk on 6/17/25.
+//
+
+import Foundation
+
+import CoreKeyChain
+
+import Alamofire
+
+final class AuthInterceptor: RequestInterceptor {
+    
+    private let retryLimit = 1
+    
+    func adapt(_ urlRequest: URLRequest, for session: Session, completion: @escaping (Result<URLRequest, Error>) -> Void) {
+        
+        var urlRequest = urlRequest
+        
+        if let token = KeychainManager.shared.load(key: .accessToken) {
+            urlRequest.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+        
+        completion(.success(urlRequest))
+    }
+    
+    func retry(_ request: Request, for session: Session, dueTo error: Error, completion: @escaping (RetryResult) -> Void) {
+        
+        guard request.retryCount < retryLimit else {
+            completion(.doNotRetry)
+            return
+        }
+
+        if let response = request.task?.response as? HTTPURLResponse,
+           response.statusCode == 401 {
+
+            print("🔄 토큰 만료 → refresh 시도")
+
+            Task {
+                let isSuccess = await self.refreshAccessToken()
+                if isSuccess {
+                    print("✅ 토큰 재발급 성공 → 재시도")
+                    completion(.retry)
+                } else {
+                    print("❌ 토큰 재발급 실패 → 중단")
+                    completion(.doNotRetry)
+                }
+            }
+        } else {
+            completion(.doNotRetry)
+        }
+    }
+}
+
+private extension AuthInterceptor {
+    func refreshAccessToken() async -> Bool {
+        print("🚀 토큰 재발급 API 호출 ==========================")
+        
+        guard let refreshToken = KeychainManager.shared.load(key: .refreshToken),
+              let accessToken = KeychainManager.shared.load(key: .accessToken) else {
+            print("❌ refreshToken 없음 → 재발급 불가")
+            return false
+        }
+        
+        let endpoint = AuthEndpoint.patchRefresh(RefreshRequestDTO(accessToken: accessToken, refreshToken: refreshToken))
+        
+        let parameters = try? endpoint.parameters.flatMap { encodable -> [String: Any]? in
+            let data = try JSONEncoder().encode(encodable)
+            return try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        }
+        
+        let session = Session.default
+        
+        let dataTask = session.request(
+               endpoint.baseURL.appendingPathComponent(endpoint.path),
+               method: endpoint.method,
+               parameters: parameters,
+               encoding: endpoint.method == .get ? URLEncoding.default : JSONEncoding.default,
+               headers: endpoint.headers
+           )
+           .validate(statusCode: 200..<300)
+           .serializingDecodable(APIResponse<AuthedResponseDTO>.self)
+        
+        let response = await dataTask.response
+
+        print("➡️ StatusCode: \(String(describing: response.response?.statusCode))")
+        
+        switch response.result {
+        case .success(let apiResponse):
+            let refreshResult = apiResponse.responseData
+            
+            KeychainManager.shared.save(key: .accessToken, value: refreshResult.accessToken)
+            KeychainManager.shared.save(key: .refreshToken, value: refreshResult.refreshToken)
+            
+            return true
+
+        case .failure(let error):
+            print("4️⃣ Refresh API 에러 발생 ==========================")
+            print("\(error)")
+            return false
+        }
+    }
+}

--- a/Soongan/Core/CoreNetwork/Sources/Base/Endpoint.swift
+++ b/Soongan/Core/CoreNetwork/Sources/Base/Endpoint.swift
@@ -1,0 +1,82 @@
+//
+//  Endpoint.swift
+//  Core
+//
+//  Created by ParkJunHyuk on 6/16/25.
+//
+
+import Foundation
+
+import CoreKeyChain
+
+import Alamofire
+
+public enum RequestBodyType {
+    case json           // raw JSON
+    case formData      // multipart/form-data
+}
+
+/// 각 API에 따라 공통된 Path 값 (존재하지 않는 경우 빈 String 값)
+public enum BasePath: String {
+    case auth = "/auth"
+    case weeklyContest = "/weekly/contests"
+    case comment = "/comments"
+    case member = "/members"
+    case report = "/report"
+    case postLike = "/posts"
+    case commentLike = "/comments/like"
+    case notification = "/notifications"
+    case fcmController = "/fcm"
+    case home = "/home"
+}
+
+public protocol APIEndpoint {
+    var basePath: BasePath { get }
+    var path: String { get }
+    var method: HTTPMethod { get }
+    var requestBodyType: RequestBodyType { get }
+    var headerType: HeaderType { get }
+    var parameters: Encodable? { get }
+}
+
+extension APIEndpoint {
+    public var baseURL: URL {
+        guard let baseURL = URL(string: Config.baseURL) else {
+            fatalError("⛔️ Base URL이 없습니다 ⛔️")
+        }
+        return baseURL
+    }
+
+    public var requestBodyType: RequestBodyType {
+        return .json
+    }
+    
+    /// 각 케이스에 맞는 HTTPHeaders 반환
+    public var headers: HTTPHeaders {
+        var headers: HTTPHeaders = [:]
+        
+        switch requestBodyType {
+        case .json:
+            headers["Content-Type"] = "application/json"
+        case .formData:
+            headers["Content-Type"] = "multipart/form-data"
+        }
+        
+        switch headerType {
+        case .accessTokenHeader:
+            if let token = KeychainManager.shared.load(key: .accessToken) {
+                headers["Authorization"] = "Bearer \(token)"
+            }
+        case .refreshTokenHeader:
+            if let token = KeychainManager.shared.load(key: .refreshToken) {
+                headers["Authorization"] = "Bearer \(token)"
+            }
+        case .defaultHeader:
+            break
+        case .userAgentHeader(let type):
+            headers["User-Agent"] = type
+        }
+        
+        return headers
+    }
+}

--- a/Soongan/Core/CoreNetwork/Sources/Base/Endpoint.swift
+++ b/Soongan/Core/CoreNetwork/Sources/Base/Endpoint.swift
@@ -36,7 +36,8 @@ public protocol APIEndpoint {
     var method: HTTPMethod { get }
     var requestBodyType: RequestBodyType { get }
     var headerType: HeaderType { get }
-    var parameters: Encodable? { get }
+    var queryParameters: [URLQueryItem]? { get }
+    var body: Encodable? { get }
 }
 
 extension APIEndpoint {
@@ -53,30 +54,6 @@ extension APIEndpoint {
     
     /// 각 케이스에 맞는 HTTPHeaders 반환
     public var headers: HTTPHeaders {
-        var headers: HTTPHeaders = [:]
-        
-        switch requestBodyType {
-        case .json:
-            headers["Content-Type"] = "application/json"
-        case .formData:
-            headers["Content-Type"] = "multipart/form-data"
-        }
-        
-        switch headerType {
-        case .accessTokenHeader:
-            if let token = KeychainManager.shared.load(key: .accessToken) {
-                headers["Authorization"] = "Bearer \(token)"
-            }
-        case .refreshTokenHeader:
-            if let token = KeychainManager.shared.load(key: .refreshToken) {
-                headers["Authorization"] = "Bearer \(token)"
-            }
-        case .defaultHeader:
-            break
-        case .userAgentHeader(let type):
-            headers["User-Agent"] = type
-        }
-        
-        return headers
+        return headerType.headers
     }
 }

--- a/Soongan/Core/CoreNetwork/Sources/Base/HeaderType.swift
+++ b/Soongan/Core/CoreNetwork/Sources/Base/HeaderType.swift
@@ -1,0 +1,70 @@
+//
+//  HeaderType.swift
+//  CoreNetwork
+//
+//  Created by ParkJunHyuk on 6/16/25.
+//
+
+import CoreKeyChain
+
+import Alamofire
+
+/// API 요청에 사용되는 HTTP 헤더 타입
+///
+/// 각 케이스별 포함되는 헤더:
+/// - defaultHeader:
+///     - "Content-Type": "application/json"
+///
+/// - accessTokenHeader:
+///     - "Content-Type": "application/json"
+///     - "Authorization": "Bearer {access_token}"
+///
+/// - refreshTokenHeader:
+///     - "Content-Type": "application/json"
+///     - "Authorization": "Bearer {refresh_token}"
+///
+/// ## 사용 예시:
+/// ```swift
+/// var headerType: HeaderType {
+///     switch self {
+///     case .login, .register:
+///         return .defaultHeader    // 인증이 필요없는 API
+///     case .refreshToken:
+///         return .refreshTokenHeader    // 토큰 갱신 API
+///     default:
+///         return .accessTokenHeader    // 일반적인 인증 필요 API
+///     }
+/// }
+/// ```
+public enum HeaderType {
+    case defaultHeader
+    case accessTokenHeader
+    case refreshTokenHeader
+    case userAgentHeader(String)
+    
+    public var headers: HTTPHeaders {
+        var headers: HTTPHeaders = [
+            "Content-Type": "application/json"
+        ]
+        
+        switch self {
+        case .accessTokenHeader:
+            if let token = KeychainManager.shared.load(key: .accessToken) {
+                headers["Authorization"] = "Bearer \(token)"
+            }
+            
+        case .refreshTokenHeader:
+            if let token = KeychainManager.shared.load(key: .refreshToken) {
+                headers["Authorization"] = "Bearer \(token)"
+            }
+            
+        case .userAgentHeader(let userAgent):
+            headers["User-Agent"] = userAgent
+            
+        case .defaultHeader:
+            break
+        }
+        
+        return headers
+    }
+}

--- a/Soongan/Core/CoreNetwork/Sources/Base/HeaderType.swift
+++ b/Soongan/Core/CoreNetwork/Sources/Base/HeaderType.swift
@@ -40,11 +40,12 @@ public enum HeaderType {
     case defaultHeader
     case accessTokenHeader
     case refreshTokenHeader
-    case userAgentHeader(String)
+    case userAgentHeader
     
     public var headers: HTTPHeaders {
         var headers: HTTPHeaders = [
-            "Content-Type": "application/json"
+            "Content-Type": "application/json",
+            "Soongan-Api-Key": "\(Config.projectKey)"
         ]
         
         switch self {
@@ -58,8 +59,8 @@ public enum HeaderType {
                 headers["Authorization"] = "Bearer \(token)"
             }
             
-        case .userAgentHeader(let userAgent):
-            headers["User-Agent"] = userAgent
+        case .userAgentHeader:
+            headers["User-Agent"] = "IOS"
             
         case .defaultHeader:
             break

--- a/Soongan/Core/CoreNetwork/Sources/Base/NetworkError.swift
+++ b/Soongan/Core/CoreNetwork/Sources/Base/NetworkError.swift
@@ -1,0 +1,54 @@
+//
+//  NetworkError.swift
+//  CoreNetwork
+//
+//  Created by ParkJunHyuk on 6/16/25.
+//
+
+import Foundation
+
+public enum NetworkError: Error {
+    case invalidURL
+    case invalidParameters
+    case requestFailed(description: String)
+    case noData
+    case decodingFailed(Error)
+    case unAuthorizedError
+    case httpResponseNotOK(statusCode: Int)
+    case encodingFailed
+    case unknown
+    case tokenRefreshFailed(Error)
+    case maxRetryExceeded
+    case tokenExpiration
+}
+
+extension NetworkError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .invalidURL:
+            return "🛠️ 유효하지 않은 URL입니다. 🛠️"
+        case .invalidParameters:
+            return "🛠️ 유효하지 않은 매개변수입니다. 🛠️"
+        case .requestFailed(let description):
+            return "네트워크 요청 실패: \(description)"
+        case .noData:
+            return "서버에서 데이터를 받지 못했습니다."
+        case .decodingFailed(let error):
+            return "⚙️ JSON Decoding 에러입니다. :\(error.localizedDescription) ⚙️"
+        case .unAuthorizedError:
+            return "⛏️ 접근 권한이 없습니다 (토큰 만료) ⛏️"
+        case .httpResponseNotOK(let statusCode):
+            return "HTTP 요청 실패: 상태 코드 \(statusCode)"
+        case .encodingFailed:
+            return "데이터 인코딩에 실패했습니다."
+        case .unknown:
+            return "📁 알 수 없는 오류가 발생했습니다. 📁"
+        case .tokenRefreshFailed(let error):
+            return "토큰 재발급 실패: \(error.localizedDescription)"
+        case .maxRetryExceeded:
+            return "재시도 할 수 있는 횟수가 초과되었습니다."
+        case .tokenExpiration:
+            return "유효하지 않은 토큰입니다."
+        }
+    }
+}

--- a/Soongan/Core/CoreNetwork/Sources/Base/NetworkLogger.swift
+++ b/Soongan/Core/CoreNetwork/Sources/Base/NetworkLogger.swift
@@ -1,0 +1,45 @@
+//
+//  NetworkLogger.swift
+//  CoreNetwork
+//
+//  Created by ParkJunHyuk on 6/18/25.
+//
+
+import Alamofire
+import Foundation
+
+public final class NetworkLogger: EventMonitor {
+    
+    public init(){}
+    
+    public let queue = DispatchQueue(label: "com.app.networklogger")
+
+    // 요청 시작할 때
+    public func requestDidResume(_ request: Request) {
+        print("➡️ [REQUEST] ==========================")
+        print("URL: \(request.request?.url?.absoluteString ?? "")")
+        print("Method: \(request.request?.httpMethod ?? "")")
+        if let headers = request.request?.allHTTPHeaderFields {
+            print("Headers: \(headers)")
+        }
+        if let bodyData = request.request?.httpBody,
+           let bodyString = String(data: bodyData, encoding: .utf8) {
+            print("Body: \(bodyString)")
+        }
+    }
+
+    // 응답 받을 때
+    public func request<Value>(_ request: DataRequest, didParseResponse response: DataResponse<Value, AFError>) {
+        print("⬅️ [RESPONSE] ==========================")
+        print("➡️ Status Code: \(response.response?.statusCode ?? 0)")
+
+        switch response.result {
+        case .success(let value):
+            print("✅ SUCCESS: ==========================")
+            print(value)
+        case .failure(let error):
+            print("❌ FAILURE:")
+            print(error.localizedDescription)
+        }
+    }
+}

--- a/Soongan/Core/CoreNetwork/Sources/Base/NetworkManager.swift
+++ b/Soongan/Core/CoreNetwork/Sources/Base/NetworkManager.swift
@@ -8,7 +8,35 @@
 import Alamofire
 import Foundation
 
-struct EmptyResponseDTO: Decodable {}
+public struct EmptyResponseDTO: Decodable {}
+
+public struct APIRouter: URLRequestConvertible {
+    public let endpoint: APIEndpoint
+
+    public init(endpoint: APIEndpoint) {
+        self.endpoint = endpoint
+    }
+    
+    public func asURLRequest() throws -> URLRequest {
+        var urlRequest = URLRequest(url: endpoint.baseURL.appendingPathComponent(endpoint.path))
+        urlRequest.method = endpoint.method
+        urlRequest.headers = endpoint.headerType.headers
+
+        // Body
+        if let body = endpoint.body {
+            urlRequest.httpBody = try JSONEncoder().encode(body)
+        }
+
+        // QueryParameters
+        if let queryParameters = endpoint.queryParameters, !queryParameters.isEmpty {
+            var components = URLComponents(url: urlRequest.url!, resolvingAgainstBaseURL: false)!
+            components.queryItems = queryParameters
+            urlRequest.url = components.url
+        }
+
+        return urlRequest
+    }
+}
 
 public final actor NetworkManager {
     
@@ -18,50 +46,24 @@ public final actor NetworkManager {
     
     private init() {
         let interceptor = AuthInterceptor()
-        self.session = Session(interceptor: interceptor)
+        self.session = Session(interceptor: interceptor, eventMonitors: [NetworkLogger()])
     }
     
     public func request<T: Decodable>(_ endpoint: APIEndpoint) async -> Result<T, NetworkError> {
-        let url = endpoint.baseURL.appendingPathComponent(endpoint.path)
-        
-        let parameters = try? endpoint.parameters.flatMap { encodable -> [String: Any]? in
-            let data = try JSONEncoder().encode(encodable)
-            return try JSONSerialization.jsonObject(with: data) as? [String: Any]
-        }
-
-        let dataTask = session.request(
-            url,
-            method: endpoint.method,
-            parameters: parameters,
-            encoding: endpoint.method == .get ? URLEncoding.default : JSONEncoding.default,
-            headers: endpoint.headers
-        )
-        .validate(statusCode: 200..<300)
-        .serializingData()
+        let dataTask = session.request(APIRouter(endpoint: endpoint))
+            .validate(statusCode: 200..<300)
+            .serializingDecodable(APIResponse<T>.self)
         
         print("🚀 \(T.self) API 호출 ==========================")
         let response = await dataTask.response
         
-        print("➡️ StatusCode: \(String(describing: response.response?.statusCode))")
-        
         switch response.result {
-        case .success(let data):
+        case .success(let decodedResponse):
+            // EmptyResponseDTO 인 경우 처리
             if T.self == EmptyResponseDTO.self {
                 return .success(EmptyResponseDTO() as! T)
             } else {
-                do {
-                    let decoded = try JSONDecoder().decode(APIResponse<T>.self, from: data)
-                    print("➡️ \(T.self) API 결과 디코딩 성공 ==========================")
-                    print(decoded.responseData)
-                    
-                    
-                    print("✅ \(T.self) API 성공 ==========================")
-                    return .success(decoded.responseData)
-                } catch {
-                    print("⚠️ \(T.self) API decodingFailed 에러 발생 ==========================")
-                    print(error.localizedDescription)
-                    return .failure(.decodingFailed(error))
-                }
+                return .success(decodedResponse.responseData)
             }
             
         case .failure(let error):
@@ -71,13 +73,14 @@ public final actor NetworkManager {
                     print("⚠️ \(T.self) API unAuthorizedError 에러 발생 ==========================")
                     return .failure(.unAuthorizedError)
                 case 400..<500, 500..<600:
+                    print("⚠️ \(T.self) API httpResponseNotOK 에러 발생 ==========================")
                     return .failure(.httpResponseNotOK(statusCode: statusCode))
                 default:
-                    return .failure(.requestFailed(description: error.localizedDescription))
+                    break
                 }
             }
             
-            print("❌ API 에러 발생: ==========================")
+            print("❌ \(T.self) API 에러 발생 ==========================")
             print(error.localizedDescription)
             return .failure(.requestFailed(description: error.localizedDescription))
         }

--- a/Soongan/Core/CoreNetwork/Sources/Base/NetworkManager.swift
+++ b/Soongan/Core/CoreNetwork/Sources/Base/NetworkManager.swift
@@ -1,0 +1,85 @@
+//
+//  NetworkManager.swift
+//  CoreNetwork
+//
+//  Created by ParkJunHyuk on 6/17/25.
+//
+
+import Alamofire
+import Foundation
+
+struct EmptyResponseDTO: Decodable {}
+
+public final actor NetworkManager {
+    
+    public static let shared = NetworkManager()
+    
+    private let session: Session
+    
+    private init() {
+        let interceptor = AuthInterceptor()
+        self.session = Session(interceptor: interceptor)
+    }
+    
+    public func request<T: Decodable>(_ endpoint: APIEndpoint) async -> Result<T, NetworkError> {
+        let url = endpoint.baseURL.appendingPathComponent(endpoint.path)
+        
+        let parameters = try? endpoint.parameters.flatMap { encodable -> [String: Any]? in
+            let data = try JSONEncoder().encode(encodable)
+            return try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        }
+
+        let dataTask = session.request(
+            url,
+            method: endpoint.method,
+            parameters: parameters,
+            encoding: endpoint.method == .get ? URLEncoding.default : JSONEncoding.default,
+            headers: endpoint.headers
+        )
+        .validate(statusCode: 200..<300)
+        .serializingData()
+        
+        print("🚀 \(T.self) API 호출 ==========================")
+        let response = await dataTask.response
+        
+        print("➡️ StatusCode: \(String(describing: response.response?.statusCode))")
+        
+        switch response.result {
+        case .success(let data):
+            if T.self == EmptyResponseDTO.self {
+                return .success(EmptyResponseDTO() as! T)
+            } else {
+                do {
+                    let decoded = try JSONDecoder().decode(APIResponse<T>.self, from: data)
+                    print("➡️ \(T.self) API 결과 디코딩 성공 ==========================")
+                    print(decoded.responseData)
+                    
+                    
+                    print("✅ \(T.self) API 성공 ==========================")
+                    return .success(decoded.responseData)
+                } catch {
+                    print("⚠️ \(T.self) API decodingFailed 에러 발생 ==========================")
+                    print(error.localizedDescription)
+                    return .failure(.decodingFailed(error))
+                }
+            }
+            
+        case .failure(let error):
+            if let statusCode = response.response?.statusCode {
+                switch statusCode {
+                case 401:
+                    print("⚠️ \(T.self) API unAuthorizedError 에러 발생 ==========================")
+                    return .failure(.unAuthorizedError)
+                case 400..<500, 500..<600:
+                    return .failure(.httpResponseNotOK(statusCode: statusCode))
+                default:
+                    return .failure(.requestFailed(description: error.localizedDescription))
+                }
+            }
+            
+            print("❌ API 에러 발생: ==========================")
+            print(error.localizedDescription)
+            return .failure(.requestFailed(description: error.localizedDescription))
+        }
+    }
+}

--- a/Soongan/Core/CoreNetwork/Sources/Config.swift
+++ b/Soongan/Core/CoreNetwork/Sources/Config.swift
@@ -1,0 +1,51 @@
+//
+//  Config.swift
+//  CoreNetwork
+//
+//  Created by ParkJunHyuk on 6/17/25.
+//
+
+import Foundation
+
+enum Config {
+    enum Keys {
+        enum Plist {
+            static let baseURL = "BASE_URL"
+        }
+        
+        enum Keychain: String {
+            case accessToken = "ACCESS_TOKEN_KEY"
+            case refreshToken = "REFRESH_TOKEN_KEY"
+        }
+    }
+    
+    private static let infoDictionary: [String: Any] = {
+        guard let dict = Bundle.main.infoDictionary else {
+            fatalError("plist cannot found !!!")
+        }
+        return dict
+    }()
+}
+
+extension Config {
+    static let baseURL: String = {
+        guard let key = Config.infoDictionary[Keys.Plist.baseURL] as? String else {
+            fatalError("⛔️BASE_URL is not set in plist for this configuration⛔️")
+        }
+        return key
+    }()
+    
+    static let accessTokenKey: String = {
+        guard let key = Config.infoDictionary[Keys.Keychain.accessToken.rawValue] as? String else {
+            fatalError("⛔️ACCESS_TOKEN_KEY is not set in plist for this configuration⛔️")
+        }
+        return key
+    }()
+    
+    static let refreshTokenKey: String = {
+        guard let key = Config.infoDictionary[Keys.Keychain.refreshToken.rawValue] as? String else {
+            fatalError("⛔️REFRESH_TOKEN_KEY is not set in plist for this configuration⛔️")
+        }
+        return key
+    }()
+}

--- a/Soongan/Core/CoreNetwork/Sources/Config.swift
+++ b/Soongan/Core/CoreNetwork/Sources/Config.swift
@@ -11,6 +11,7 @@ enum Config {
     enum Keys {
         enum Plist {
             static let baseURL = "BASE_URL"
+            static let projectHeader = "PROJECT_KEY"
         }
         
         enum Keychain: String {
@@ -45,6 +46,13 @@ extension Config {
     static let refreshTokenKey: String = {
         guard let key = Config.infoDictionary[Keys.Keychain.refreshToken.rawValue] as? String else {
             fatalError("⛔️REFRESH_TOKEN_KEY is not set in plist for this configuration⛔️")
+        }
+        return key
+    }()
+    
+    static let projectKey: String = {
+        guard let key = Config.infoDictionary[Keys.Plist.projectHeader] as? String else {
+            fatalError("⛔️PROJECT_KEY is not set in plist for this configuration⛔️")
         }
         return key
     }()

--- a/Soongan/Core/CoreNetwork/Sources/Fcm/DTO/Request/FCMTokenRequestDTO.swift
+++ b/Soongan/Core/CoreNetwork/Sources/Fcm/DTO/Request/FCMTokenRequestDTO.swift
@@ -1,0 +1,12 @@
+//
+//  FCMTokenRequestDTO.swift
+//  CoreNetwork
+//
+//  Created by ParkJunHyuk on 6/18/25.
+//
+
+import Foundation
+
+public struct FCMTokenRequestDTO: Encodable, QueryParameterConvertible {
+    let fcmToken: String
+}

--- a/Soongan/Core/CoreNetwork/Sources/Fcm/DTO/Request/RegisterFCMTokenRequestDTO.swift
+++ b/Soongan/Core/CoreNetwork/Sources/Fcm/DTO/Request/RegisterFCMTokenRequestDTO.swift
@@ -10,4 +10,9 @@ import Foundation
 public struct RegisterFCMTokenRequestDTO: Encodable {
     let token: String
     let deviceId: String
+    
+    public init(token: String, deviceId: String) {
+        self.token = token
+        self.deviceId = deviceId
+    }
 }

--- a/Soongan/Core/CoreNetwork/Sources/Fcm/DTO/Request/RegisterFCMTokenRequestDTO.swift
+++ b/Soongan/Core/CoreNetwork/Sources/Fcm/DTO/Request/RegisterFCMTokenRequestDTO.swift
@@ -1,0 +1,13 @@
+//
+//  RegisterFCMTokenRequestDTO.swift
+//  CoreNetwork
+//
+//  Created by ParkJunHyuk on 6/17/25.
+//
+
+import Foundation
+
+public struct RegisterFCMTokenRequestDTO: Encodable {
+    let token: String
+    let deviceId: String
+}

--- a/Soongan/Core/CoreNetwork/Sources/Fcm/DTO/Response/RegisterFCMTokenResponseDTO.swift
+++ b/Soongan/Core/CoreNetwork/Sources/Fcm/DTO/Response/RegisterFCMTokenResponseDTO.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct RegisterFCMTokenResponseDTO: Encodable {
+public struct RegisterFCMTokenResponseDTO: Decodable {
     let id: Int
     let token: String
     let deviceId: String

--- a/Soongan/Core/CoreNetwork/Sources/Fcm/DTO/Response/RegisterFCMTokenResponseDTO.swift
+++ b/Soongan/Core/CoreNetwork/Sources/Fcm/DTO/Response/RegisterFCMTokenResponseDTO.swift
@@ -1,0 +1,15 @@
+//
+//  RegisterFCMTokenResponseDTO.swift
+//  CoreNetwork
+//
+//  Created by ParkJunHyuk on 6/17/25.
+//
+
+import Foundation
+
+public struct RegisterFCMTokenResponseDTO: Encodable {
+    let id: Int
+    let token: String
+    let deviceId: String
+    let deviceType: String
+}

--- a/Soongan/Core/CoreNetwork/Sources/Fcm/FCMEndpoint.swift
+++ b/Soongan/Core/CoreNetwork/Sources/Fcm/FCMEndpoint.swift
@@ -1,0 +1,50 @@
+//
+//  FCMEndpoint.swift
+//  CoreNetwork
+//
+//  Created by ParkJunHyuk on 6/16/25.
+//
+
+import Alamofire
+
+public enum FCMEndpoint {
+    case postFcmToken
+    case getFcmTest
+}
+
+extension FCMEndpoint: APIEndpoint {
+    public var basePath: BasePath {
+        return .fcmController
+    }
+    
+    public var path: String {
+        switch self {
+        case .postFcmToken:
+            return basePath.rawValue
+        case .getFcmTest:
+            return basePath.rawValue + "/test"
+        }
+    }
+    
+    public var method: Alamofire.HTTPMethod {
+        switch self {
+        case .postFcmToken:
+            return .post
+        case .getFcmTest:
+            return .get
+        }
+    }
+    
+    public var headerType: HeaderType {
+        switch self {
+        case .postFcmToken:
+            return .userAgentHeader("IOS")
+        case .getFcmTest:
+            return .defaultHeader
+        }
+    }
+    
+    public var parameters: (any Encodable)? {
+        return nil
+    }
+}

--- a/Soongan/Core/CoreNetwork/Sources/Fcm/FCMEndpoint.swift
+++ b/Soongan/Core/CoreNetwork/Sources/Fcm/FCMEndpoint.swift
@@ -6,10 +6,11 @@
 //
 
 import Alamofire
+import Foundation
 
 public enum FCMEndpoint {
-    case postFcmToken
-    case getFcmTest
+    case postFcmToken(RegisterFCMTokenRequestDTO)
+    case getFcmTest(FCMTokenRequestDTO)
 }
 
 extension FCMEndpoint: APIEndpoint {
@@ -38,13 +39,27 @@ extension FCMEndpoint: APIEndpoint {
     public var headerType: HeaderType {
         switch self {
         case .postFcmToken:
-            return .userAgentHeader("IOS")
+            return .userAgentHeader
         case .getFcmTest:
             return .defaultHeader
         }
     }
     
-    public var parameters: (any Encodable)? {
-        return nil
+    public var queryParameters: [URLQueryItem]? {
+        switch self {
+        case .getFcmTest(let dto):
+            return dto.toQueryItems()
+        default:
+            return nil
+        }
+    }
+    
+    public var body: (any Encodable)? {
+        switch self {
+        case .postFcmToken(let dto):
+            return dto
+        default:
+            return nil
+        }
     }
 }

--- a/Soongan/Core/CoreNetwork/Sources/Home/HomeEndpoint.swift
+++ b/Soongan/Core/CoreNetwork/Sources/Home/HomeEndpoint.swift
@@ -1,0 +1,34 @@
+//
+//  HomeEndpoint.swift
+//  CoreNetwork
+//
+//  Created by ParkJunHyuk on 6/16/25.
+//
+
+import Alamofire
+
+public enum HomeEndpoint {
+    case getHomeInfo
+}
+
+extension HomeEndpoint: APIEndpoint {
+    public var basePath: BasePath {
+        return .home
+    }
+    
+    public var path: String {
+        return basePath.rawValue
+    }
+    
+    public var method: Alamofire.HTTPMethod {
+        return .get
+    }
+    
+    public var headerType: HeaderType {
+        return .accessTokenHeader
+    }
+    
+    public var parameters: (any Encodable)? {
+        return nil
+    }
+}

--- a/Soongan/Core/CoreNetwork/Sources/Home/HomeEndpoint.swift
+++ b/Soongan/Core/CoreNetwork/Sources/Home/HomeEndpoint.swift
@@ -6,6 +6,7 @@
 //
 
 import Alamofire
+import Foundation
 
 public enum HomeEndpoint {
     case getHomeInfo
@@ -28,7 +29,11 @@ extension HomeEndpoint: APIEndpoint {
         return .accessTokenHeader
     }
     
-    public var parameters: (any Encodable)? {
+    public var queryParameters: [URLQueryItem]? {
+        return nil
+    }
+    
+    public var body: (any Encodable)? {
         return nil
     }
 }

--- a/Soongan/Core/CoreNetwork/Sources/Home/SearchHomeInfoResponseDTO.swift
+++ b/Soongan/Core/CoreNetwork/Sources/Home/SearchHomeInfoResponseDTO.swift
@@ -8,20 +8,20 @@
 import Foundation
 
 public struct SearchHomeInfoResponseDTO: Decodable {
-    let contestInfo: ContestInfoData
-    let postInfo: [HomePostInfoData]
+    public let contestInfo: ContestInfoData
+    public let postInfo: [HomePostInfoData]
 }
 
 public struct ContestInfoData: Decodable {
-    let contestType: String
-    let subject: String
-    let startAt: String
-    let endAt: String
+    public let contestType: String
+    public let subject: String
+    public let startAt: String
+    public let endAt: String
 }
 
 public struct HomePostInfoData: Decodable {
-    let postId: Int
-    let imageUrl: String
-    let likeCount: Int
-    let commentCount: Int
+    public let postId: Int
+    public let imageUrl: String
+    public let likeCount: Int
+    public let commentCount: Int
 }

--- a/Soongan/Core/CoreNetwork/Sources/Home/SearchHomeInfoResponseDTO.swift
+++ b/Soongan/Core/CoreNetwork/Sources/Home/SearchHomeInfoResponseDTO.swift
@@ -1,0 +1,27 @@
+//
+//  SearchHomeInfoResponseDTO.swift
+//  CoreNetwork
+//
+//  Created by ParkJunHyuk on 6/16/25.
+//
+
+import Foundation
+
+public struct SearchHomeInfoResponseDTO: Decodable {
+    let contestInfo: ContestInfoData
+    let postInfo: [HomePostInfoData]
+}
+
+public struct ContestInfoData: Decodable {
+    let contestType: String
+    let subject: String
+    let startAt: String
+    let endAt: String
+}
+
+public struct HomePostInfoData: Decodable {
+    let postId: Int
+    let imageUrl: String
+    let likeCount: Int
+    let commentCount: Int
+}

--- a/Soongan/Core/CoreNetwork/Sources/Member/DTO/Request/CheckNickNameRequestDTO.swift
+++ b/Soongan/Core/CoreNetwork/Sources/Member/DTO/Request/CheckNickNameRequestDTO.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct CheckNickNameRequestDTO: Encodable {
+public struct CheckNickNameRequestDTO: Encodable, QueryParameterConvertible {
     let nickname: String
     
     public init(nickname: String) {

--- a/Soongan/Core/CoreNetwork/Sources/Member/DTO/Request/CheckNickNameRequestDTO.swift
+++ b/Soongan/Core/CoreNetwork/Sources/Member/DTO/Request/CheckNickNameRequestDTO.swift
@@ -1,0 +1,16 @@
+//
+//  CheckNickNameRequestDTO.swift
+//  CoreNetwork
+//
+//  Created by ParkJunHyuk on 6/16/25.
+//
+
+import Foundation
+
+public struct CheckNickNameRequestDTO: Encodable {
+    let nickname: String
+    
+    public init(nickname: String) {
+        self.nickname = nickname
+    }
+}

--- a/Soongan/Core/CoreNetwork/Sources/Member/DTO/Request/EditMyBirthYearRequestDTO.swift
+++ b/Soongan/Core/CoreNetwork/Sources/Member/DTO/Request/EditMyBirthYearRequestDTO.swift
@@ -1,0 +1,16 @@
+//
+//  EditMyBirthYearRequestDTO.swift
+//  CoreNetwork
+//
+//  Created by ParkJunHyuk on 6/16/25.
+//
+
+import Foundation
+
+public struct EditMyBirthYearRequestDTO: Encodable {
+    let birthYear: Int
+    
+    public init(birthYear: Int) {
+        self.birthYear = birthYear
+    }
+}

--- a/Soongan/Core/CoreNetwork/Sources/Member/DTO/Request/EditMyBirthYearRequestDTO.swift
+++ b/Soongan/Core/CoreNetwork/Sources/Member/DTO/Request/EditMyBirthYearRequestDTO.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct EditMyBirthYearRequestDTO: Encodable {
+public struct EditMyBirthYearRequestDTO: Encodable, QueryParameterConvertible {
     let birthYear: Int
     
     public init(birthYear: Int) {

--- a/Soongan/Core/CoreNetwork/Sources/Member/DTO/Request/EditMyProfileRequestDTO.swift
+++ b/Soongan/Core/CoreNetwork/Sources/Member/DTO/Request/EditMyProfileRequestDTO.swift
@@ -1,0 +1,15 @@
+//
+//  EditMyProfileRequestDTO.swift
+//  CoreNetwork
+//
+//  Created by ParkJunHyuk on 6/16/25.
+//
+
+import Foundation
+
+public struct EditMyProfileRequestDTO: Encodable {
+    let nickname: String
+    let selfIntroduction: String
+    let profileImage: String
+    let isDefaultProfileImage: Bool
+}

--- a/Soongan/Core/CoreNetwork/Sources/Member/DTO/Request/EditMyProfileRequestDTO.swift
+++ b/Soongan/Core/CoreNetwork/Sources/Member/DTO/Request/EditMyProfileRequestDTO.swift
@@ -12,4 +12,11 @@ public struct EditMyProfileRequestDTO: Encodable {
     let selfIntroduction: String
     let profileImage: String
     let isDefaultProfileImage: Bool
+    
+    public init(nickname: String, selfIntroduction: String, profileImage: String, isDefaultProfileImage: Bool) {
+        self.nickname = nickname
+        self.selfIntroduction = selfIntroduction
+        self.profileImage = profileImage
+        self.isDefaultProfileImage = isDefaultProfileImage
+    }
 }

--- a/Soongan/Core/CoreNetwork/Sources/Member/DTO/Response/EditMyBirthYearResponseDTO.swift
+++ b/Soongan/Core/CoreNetwork/Sources/Member/DTO/Response/EditMyBirthYearResponseDTO.swift
@@ -1,0 +1,12 @@
+//
+//  EditMyBirthYearResponseDTO.swift
+//  CoreNetwork
+//
+//  Created by ParkJunHyuk on 6/16/25.
+//
+
+import Foundation
+
+public struct EditMyBirthYearResponseDTO: Decodable {
+    let birthYear: Int
+}

--- a/Soongan/Core/CoreNetwork/Sources/Member/DTO/Response/EditMyProfileResponseDTO.swift
+++ b/Soongan/Core/CoreNetwork/Sources/Member/DTO/Response/EditMyProfileResponseDTO.swift
@@ -1,0 +1,14 @@
+//
+//  EditMyProfileResponseDTO.swift
+//  CoreNetwork
+//
+//  Created by ParkJunHyuk on 7/1/25.
+//
+
+import Foundation
+
+public struct EditMyProfileResponseDTO: Decodable {
+    public let nickname: String
+    public let selfIntroduction: String
+    public let profileImageUrl: String
+}

--- a/Soongan/Core/CoreNetwork/Sources/Member/DTO/Response/SearchMyProfileResponseDTO.swift
+++ b/Soongan/Core/CoreNetwork/Sources/Member/DTO/Response/SearchMyProfileResponseDTO.swift
@@ -8,16 +8,16 @@
 import Foundation
 
 public struct SearchMyProfileResponseDTO: Decodable {
-    let email: String
-    let nickname: String
-    let birthYear: Int
-    let profileImageUrl: String
-    let selfIntroduction: String
-    let reportHistories: [ReportHistoryData]
+    public let email: String
+    public let nickname: String?
+    public let birthYear: Int
+    public let profileImageUrl: String?
+    public let selfIntroduction: String?
+    public let reportHistories: [ReportHistoryData?]
 }
 
 public struct ReportHistoryData: Decodable {
-    let id: Int
-    let targetId: Int
-    let targetType: String
+    public let id: Int
+    public let targetId: Int
+    public let targetType: String
 }

--- a/Soongan/Core/CoreNetwork/Sources/Member/DTO/Response/SearchMyProfileResponseDTO.swift
+++ b/Soongan/Core/CoreNetwork/Sources/Member/DTO/Response/SearchMyProfileResponseDTO.swift
@@ -1,0 +1,23 @@
+//
+//  SearchMyProfileResponseDTO.swift
+//  CoreNetwork
+//
+//  Created by ParkJunHyuk on 6/16/25.
+//
+
+import Foundation
+
+public struct SearchMyProfileResponseDTO: Decodable {
+    let email: String
+    let nickname: String
+    let birthYear: Int
+    let profileImageUrl: String
+    let selfIntroduction: String
+    let reportHistories: [ReportHistoryData]
+}
+
+public struct ReportHistoryData: Decodable {
+    let id: Int
+    let targetId: Int
+    let targetType: String
+}

--- a/Soongan/Core/CoreNetwork/Sources/Member/MemberEndpoint.swift
+++ b/Soongan/Core/CoreNetwork/Sources/Member/MemberEndpoint.swift
@@ -1,0 +1,58 @@
+//
+//  MemberEndpoint.swift
+//  CoreNetwork
+//
+//  Created by ParkJunHyuk on 6/16/25.
+//
+
+import Alamofire
+
+public enum MemberEndpoint {
+    case patchProfile
+    case patchBirthYear(EditMyBirthYearRequestDTO)
+    case getMembers
+    case getCheckNickname(CheckNickNameRequestDTO)
+}
+
+extension MemberEndpoint: APIEndpoint {
+    public var basePath: BasePath {
+        return .member
+    }
+    
+    public var path: String {
+        switch self {
+        case .patchProfile:
+            return basePath.rawValue + "/profile"
+        case .patchBirthYear:
+            return basePath.rawValue + "/birth-year"
+        case .getMembers:
+            return basePath.rawValue
+        case .getCheckNickname:
+            return basePath.rawValue + "/check-nickname"
+        }
+    }
+    
+    public var method: Alamofire.HTTPMethod {
+        switch self {
+        case .patchProfile, .patchBirthYear:
+            return .patch
+        case .getMembers, .getCheckNickname:
+            return .get
+        }
+    }
+    
+    public var headerType: HeaderType {
+        return .accessTokenHeader
+    }
+    
+    public var parameters: (any Encodable)? {
+        switch self {
+        case .getCheckNickname(let dto):
+            return dto
+        case .patchBirthYear(let dto):
+            return dto
+        default:
+            return nil
+        }
+    }
+}

--- a/Soongan/Core/CoreNetwork/Sources/Member/MemberEndpoint.swift
+++ b/Soongan/Core/CoreNetwork/Sources/Member/MemberEndpoint.swift
@@ -6,9 +6,10 @@
 //
 
 import Alamofire
+import Foundation
 
 public enum MemberEndpoint {
-    case patchProfile
+    case patchProfile(EditMyProfileRequestDTO)
     case patchBirthYear(EditMyBirthYearRequestDTO)
     case getMembers
     case getCheckNickname(CheckNickNameRequestDTO)
@@ -45,11 +46,20 @@ extension MemberEndpoint: APIEndpoint {
         return .accessTokenHeader
     }
     
-    public var parameters: (any Encodable)? {
+    public var queryParameters: [URLQueryItem]? {
         switch self {
-        case .getCheckNickname(let dto):
-            return dto
         case .patchBirthYear(let dto):
+            return dto.toQueryItems()
+        case .getCheckNickname(let dto):
+            return dto.toQueryItems()
+        default:
+            return nil
+        }
+    }
+    
+    public var body: (any Encodable)? {
+        switch self {
+        case .patchProfile(let dto):
             return dto
         default:
             return nil

--- a/Soongan/Core/CoreNetwork/Sources/Notification/DTO/Request/ReadNotificationsRequestDTO.swift
+++ b/Soongan/Core/CoreNetwork/Sources/Notification/DTO/Request/ReadNotificationsRequestDTO.swift
@@ -1,0 +1,16 @@
+//
+//  ReadNotificationsRequestDTO.swift
+//  CoreNetwork
+//
+//  Created by ParkJunHyuk on 6/18/25.
+//
+
+import Foundation
+
+public struct ReadNotificationsRequestDTO: Encodable, QueryParameterConvertible {
+    let notificationId: Int
+    
+    public init(notificationId: Int) {
+        self.notificationId = notificationId
+    }
+}

--- a/Soongan/Core/CoreNetwork/Sources/Notification/DTO/Request/SearchNotificationsRequestDTO.swift
+++ b/Soongan/Core/CoreNetwork/Sources/Notification/DTO/Request/SearchNotificationsRequestDTO.swift
@@ -7,6 +7,10 @@
 
 import Foundation
 
-public struct SearchNotificationsRequestDTO: Encodable {
+public struct SearchNotificationsRequestDTO: Encodable, QueryParameterConvertible {
     let type: String
+    
+    public init(type: String) {
+        self.type = type
+    }
 }

--- a/Soongan/Core/CoreNetwork/Sources/Notification/DTO/Request/SearchNotificationsRequestDTO.swift
+++ b/Soongan/Core/CoreNetwork/Sources/Notification/DTO/Request/SearchNotificationsRequestDTO.swift
@@ -1,0 +1,12 @@
+//
+//  SearchNotificationsRequestDTO.swift
+//  CoreNetwork
+//
+//  Created by ParkJunHyuk on 6/16/25.
+//
+
+import Foundation
+
+public struct SearchNotificationsRequestDTO: Encodable {
+    let type: String
+}

--- a/Soongan/Core/CoreNetwork/Sources/Notification/DTO/Response/SearchNotificationsResponseDTO.swift
+++ b/Soongan/Core/CoreNetwork/Sources/Notification/DTO/Response/SearchNotificationsResponseDTO.swift
@@ -1,0 +1,23 @@
+//
+//  SearchNotificationsResponseDTO.swift
+//  CoreNetwork
+//
+//  Created by ParkJunHyuk on 6/16/25.
+//
+
+import Foundation
+
+public struct SearchNotificationsResponseDTO: Decodable {
+    let type: String
+    let notifications: NotificationsInfoData
+}
+
+public struct NotificationsInfoData: Decodable {
+    let id: Int
+    let title: String
+    let body: String
+    let subType: String
+    let isRead: Bool
+    let redirectUrl: String
+    let createdAt: String
+}

--- a/Soongan/Core/CoreNetwork/Sources/Notification/DTO/Response/SearchNotificationsResponseDTO.swift
+++ b/Soongan/Core/CoreNetwork/Sources/Notification/DTO/Response/SearchNotificationsResponseDTO.swift
@@ -8,16 +8,16 @@
 import Foundation
 
 public struct SearchNotificationsResponseDTO: Decodable {
-    let type: String
-    let notifications: NotificationsInfoData
+    public let type: String
+    public let notifications: [NotificationsInfoData]
 }
 
 public struct NotificationsInfoData: Decodable {
-    let id: Int
-    let title: String
-    let body: String
-    let subType: String
-    let isRead: Bool
-    let redirectUrl: String
-    let createdAt: String
+    public let id: Int
+    public let title: String
+    public let body: String
+    public let subType: String
+    public let isRead: Bool
+    public let redirectUrl: String
+    public let createdAt: String
 }

--- a/Soongan/Core/CoreNetwork/Sources/Notification/DTO/Response/UnreadNotificationsResponseDTO.swift
+++ b/Soongan/Core/CoreNetwork/Sources/Notification/DTO/Response/UnreadNotificationsResponseDTO.swift
@@ -1,0 +1,13 @@
+//
+//  UnreadNotificationsResponseDTO.swift
+//  CoreNetwork
+//
+//  Created by ParkJunHyuk on 6/26/25.
+//
+
+import Foundation
+
+public struct UnreadNotificationsResponseDTO: Decodable {
+    public let count: Int
+    public let type: String
+}

--- a/Soongan/Core/CoreNetwork/Sources/Notification/NotificationEndpoint.swift
+++ b/Soongan/Core/CoreNetwork/Sources/Notification/NotificationEndpoint.swift
@@ -1,0 +1,58 @@
+//
+//  NotificationEndpoint.swift
+//  CoreNetwork
+//
+//  Created by ParkJunHyuk on 6/16/25.
+//
+
+import Alamofire
+
+public enum NotificationEndpoint {
+    case postReadNotification(notificationId: Int)
+    case getNotifications(SearchNotificationsRequestDTO)
+    case getUnreadNotificationCount
+    case deleteNotification(notificationId: Int)
+}
+
+extension NotificationEndpoint: APIEndpoint {
+    public var basePath: BasePath {
+        return .notification
+    }
+    
+    public var path: String {
+        switch self {
+        case .postReadNotification(let notificationId):
+            return basePath.rawValue + "/\(notificationId)/read"
+        case .getNotifications:
+            return basePath.rawValue
+        case .getUnreadNotificationCount:
+            return basePath.rawValue + "/unread-count"
+        case .deleteNotification(let notificationId):
+            return basePath.rawValue + "/\(notificationId)"
+        }
+    }
+    
+    public var method: Alamofire.HTTPMethod {
+        switch self {
+        case .postReadNotification:
+            return .post
+        case .getNotifications, .getUnreadNotificationCount:
+            return .get
+        case .deleteNotification:
+            return .delete
+        }
+    }
+    
+    public var headerType: HeaderType {
+        return .accessTokenHeader
+    }
+    
+    public var parameters: (any Encodable)? {
+        switch self {
+        case .getNotifications(let dto):
+            return dto
+        default:
+            return nil
+        }
+    }
+}

--- a/Soongan/Core/CoreNetwork/Sources/Notification/NotificationEndpoint.swift
+++ b/Soongan/Core/CoreNetwork/Sources/Notification/NotificationEndpoint.swift
@@ -6,9 +6,10 @@
 //
 
 import Alamofire
+import Foundation
 
 public enum NotificationEndpoint {
-    case postReadNotification(notificationId: Int)
+    case postReadNotification(ReadNotificationsRequestDTO)
     case getNotifications(SearchNotificationsRequestDTO)
     case getUnreadNotificationCount
     case deleteNotification(notificationId: Int)
@@ -47,12 +48,18 @@ extension NotificationEndpoint: APIEndpoint {
         return .accessTokenHeader
     }
     
-    public var parameters: (any Encodable)? {
+    public var queryParameters: [URLQueryItem]? {
         switch self {
+        case .postReadNotification(let dto):
+            return dto.toQueryItems()
         case .getNotifications(let dto):
-            return dto
+            return dto.toQueryItems()
         default:
             return nil
         }
+    }
+    
+    public var body: (any Encodable)? {
+        return nil
     }
 }

--- a/Soongan/Core/CoreNetwork/Sources/PostLike/DTO/Request/PostLikeRequestDTO.swift
+++ b/Soongan/Core/CoreNetwork/Sources/PostLike/DTO/Request/PostLikeRequestDTO.swift
@@ -10,4 +10,9 @@ import Foundation
 public struct PostLikeRequestDTO: Encodable {
     let postId: String
     let contestType: String
+    
+    public init(postId: String, contestType: String) {
+        self.postId = postId
+        self.contestType = contestType
+    }
 }

--- a/Soongan/Core/CoreNetwork/Sources/PostLike/DTO/Request/PostLikeRequestDTO.swift
+++ b/Soongan/Core/CoreNetwork/Sources/PostLike/DTO/Request/PostLikeRequestDTO.swift
@@ -1,0 +1,13 @@
+//
+//  PostLikeRequestDTO.swift
+//  CoreNetwork
+//
+//  Created by ParkJunHyuk on 6/16/25.
+//
+
+import Foundation
+
+public struct PostLikeRequestDTO: Encodable {
+    let postId: String
+    let contestType: String
+}

--- a/Soongan/Core/CoreNetwork/Sources/PostLike/DTO/Response/PostLikeResponseDTO.swift
+++ b/Soongan/Core/CoreNetwork/Sources/PostLike/DTO/Response/PostLikeResponseDTO.swift
@@ -1,0 +1,13 @@
+//
+//  PostLikeResponseDTO.swift
+//  CoreNetwork
+//
+//  Created by ParkJunHyuk on 6/16/25.
+//
+
+import Foundation
+
+public struct PostLikeResponseDTO: Decodable {
+    let postId: String
+    let likeCount: String
+}

--- a/Soongan/Core/CoreNetwork/Sources/PostLike/DTO/Response/PostLikeResponseDTO.swift
+++ b/Soongan/Core/CoreNetwork/Sources/PostLike/DTO/Response/PostLikeResponseDTO.swift
@@ -8,6 +8,6 @@
 import Foundation
 
 public struct PostLikeResponseDTO: Decodable {
-    let postId: String
-    let likeCount: String
+    public let postId: String
+    public let likeCount: String
 }

--- a/Soongan/Core/CoreNetwork/Sources/PostLike/PostLikeEndpoint.swift
+++ b/Soongan/Core/CoreNetwork/Sources/PostLike/PostLikeEndpoint.swift
@@ -1,0 +1,43 @@
+//
+//  PostLikeEndpoint.swift
+//  CoreNetwork
+//
+//  Created by ParkJunHyuk on 6/16/25.
+//
+
+import Alamofire
+
+public enum PostLikeEndpoint {
+    case putPostLike(PostLikeRequestDTO)
+    case deletePostLike(PostLikeRequestDTO)
+}
+
+extension PostLikeEndpoint: APIEndpoint {
+    public var basePath: BasePath {
+        return .postLike
+    }
+    
+    public var path: String {
+        return basePath.rawValue
+    }
+    
+    public var method: Alamofire.HTTPMethod {
+        switch self {
+        case .putPostLike:
+            return .post
+        case .deletePostLike:
+            return .delete
+        }
+    }
+    
+    public var headerType: HeaderType {
+        return .accessTokenHeader
+    }
+    
+    public var parameters: (any Encodable)? {
+        switch self {
+        case .putPostLike(let dto), .deletePostLike(let dto):
+            return dto
+        }
+    }
+}

--- a/Soongan/Core/CoreNetwork/Sources/PostLike/PostLikeEndpoint.swift
+++ b/Soongan/Core/CoreNetwork/Sources/PostLike/PostLikeEndpoint.swift
@@ -6,6 +6,7 @@
 //
 
 import Alamofire
+import Foundation
 
 public enum PostLikeEndpoint {
     case putPostLike(PostLikeRequestDTO)
@@ -34,7 +35,11 @@ extension PostLikeEndpoint: APIEndpoint {
         return .accessTokenHeader
     }
     
-    public var parameters: (any Encodable)? {
+    public var queryParameters: [URLQueryItem]? {
+        return nil
+    }
+    
+    public var body: (any Encodable)? {
         switch self {
         case .putPostLike(let dto), .deletePostLike(let dto):
             return dto

--- a/Soongan/Core/CoreNetwork/Sources/QueryParameterConvertible.swift
+++ b/Soongan/Core/CoreNetwork/Sources/QueryParameterConvertible.swift
@@ -1,0 +1,23 @@
+//
+//  QueryParameterConvertible.swift
+//  CoreNetwork
+//
+//  Created by ParkJunHyuk on 6/18/25.
+//
+
+import Foundation
+
+protocol QueryParameterConvertible: Encodable {
+    func toQueryItems() -> [URLQueryItem]
+}
+
+extension QueryParameterConvertible {
+    func toQueryItems() -> [URLQueryItem] {
+        guard let data = try? JSONEncoder().encode(self),
+              let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return []
+        }
+
+        return dict.map { URLQueryItem(name: $0.key, value: "\($0.value)") }
+    }
+}

--- a/Soongan/Core/CoreNetwork/Sources/Report/DTO/Request/ReportRequestDTO.swift
+++ b/Soongan/Core/CoreNetwork/Sources/Report/DTO/Request/ReportRequestDTO.swift
@@ -1,0 +1,15 @@
+//
+//  ReportRequestDTO.swift
+//  CoreNetwork
+//
+//  Created by ParkJunHyuk on 6/16/25.
+//
+
+import Foundation
+
+public struct ReportRequestDTO: Encodable {
+    let targetId: Int
+    let targetType: String
+    let reportType: String
+    let reason: String
+}

--- a/Soongan/Core/CoreNetwork/Sources/Report/DTO/Response/ReportResponseDTO.swift
+++ b/Soongan/Core/CoreNetwork/Sources/Report/DTO/Response/ReportResponseDTO.swift
@@ -1,0 +1,19 @@
+//
+//  ReportResponseDTO.swift
+//  CoreNetwork
+//
+//  Created by ParkJunHyuk on 6/16/25.
+//
+
+import Foundation
+
+public struct ReportResponseDTO: Decodable {
+    let id: Int
+    let reportMemberId: Int
+    let targetMemberId: Int
+    let targetId: Int
+    let targetType: String
+    let reportType: String
+    let reason: String
+    let reportHistories: [ReportHistoryData]
+}

--- a/Soongan/Core/CoreNetwork/Sources/Report/ReportEndpoint.swift
+++ b/Soongan/Core/CoreNetwork/Sources/Report/ReportEndpoint.swift
@@ -1,0 +1,37 @@
+//
+//  ReportEndpoint.swift
+//  CoreNetwork
+//
+//  Created by ParkJunHyuk on 6/16/25.
+//
+
+import Alamofire
+
+public enum ReportEndpoint {
+    case postReport(ReportRequestDTO)
+}
+
+extension ReportEndpoint: APIEndpoint {
+    public var basePath: BasePath {
+        return .report
+    }
+    
+    public var path: String {
+        return basePath.rawValue
+    }
+    
+    public var method: Alamofire.HTTPMethod {
+        return .post
+    }
+    
+    public var headerType: HeaderType {
+        return .accessTokenHeader
+    }
+    
+    public var parameters: (any Encodable)? {
+        switch self {
+        case .postReport(let dto):
+            return dto
+        }
+    }
+}

--- a/Soongan/Core/CoreNetwork/Sources/Report/ReportEndpoint.swift
+++ b/Soongan/Core/CoreNetwork/Sources/Report/ReportEndpoint.swift
@@ -6,6 +6,7 @@
 //
 
 import Alamofire
+import Foundation
 
 public enum ReportEndpoint {
     case postReport(ReportRequestDTO)
@@ -28,7 +29,11 @@ extension ReportEndpoint: APIEndpoint {
         return .accessTokenHeader
     }
     
-    public var parameters: (any Encodable)? {
+    public var queryParameters: [URLQueryItem]? {
+        return nil
+    }
+    
+    public var body: (any Encodable)? {
         switch self {
         case .postReport(let dto):
             return dto

--- a/Soongan/Core/CoreNetwork/Sources/WeeklyContest/DTO/Request/PostWeeklyContestRequestDTO.swift
+++ b/Soongan/Core/CoreNetwork/Sources/WeeklyContest/DTO/Request/PostWeeklyContestRequestDTO.swift
@@ -1,0 +1,13 @@
+//
+//  PostWeeklyContestRequestDTO.swift
+//  CoreNetwork
+//
+//  Created by ParkJunHyuk on 6/16/25.
+//
+
+import Foundation
+
+public struct PostWeeklyContestRequestDTO: Encodable {
+    let title: String
+    let imageFile: String
+}

--- a/Soongan/Core/CoreNetwork/Sources/WeeklyContest/DTO/Request/SearchMyContestRequestDTO.swift
+++ b/Soongan/Core/CoreNetwork/Sources/WeeklyContest/DTO/Request/SearchMyContestRequestDTO.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct SearchMyContestRequestDTO: Encodable {
+public struct SearchMyContestRequestDTO: Encodable, QueryParameterConvertible {
     let page: Int
     let pageSize: Int
     

--- a/Soongan/Core/CoreNetwork/Sources/WeeklyContest/DTO/Request/SearchMyContestRequestDTO.swift
+++ b/Soongan/Core/CoreNetwork/Sources/WeeklyContest/DTO/Request/SearchMyContestRequestDTO.swift
@@ -1,0 +1,21 @@
+//
+//  SearchMyContestRequestDTO.swift
+//  CoreNetwork
+//
+//  Created by ParkJunHyuk on 6/16/25.
+//
+
+import Foundation
+
+public struct SearchMyContestRequestDTO: Encodable {
+    let page: Int
+    let pageSize: Int
+    
+    public init(
+        page: Int = 0,
+        pageSize: Int = 50
+    ) {
+        self.page = page
+        self.pageSize = pageSize
+    }
+}

--- a/Soongan/Core/CoreNetwork/Sources/WeeklyContest/DTO/Request/SearchWeeklyContestRequestDTO.swift
+++ b/Soongan/Core/CoreNetwork/Sources/WeeklyContest/DTO/Request/SearchWeeklyContestRequestDTO.swift
@@ -7,9 +7,16 @@
 
 import Foundation
 
-public struct SearchWeeklyContestRequestDTO: Encodable {
+public struct SearchWeeklyContestRequestDTO: Encodable, QueryParameterConvertible {
     let round: Int
     let orderCriteria: String
     let page: Int
     let pageSize: Int
+    
+    public init(round: Int, orderCriteria: String, page: Int, pageSize: Int) {
+        self.round = round
+        self.orderCriteria = orderCriteria
+        self.page = page
+        self.pageSize = pageSize
+    }
 }

--- a/Soongan/Core/CoreNetwork/Sources/WeeklyContest/DTO/Request/SearchWeeklyContestRequestDTO.swift
+++ b/Soongan/Core/CoreNetwork/Sources/WeeklyContest/DTO/Request/SearchWeeklyContestRequestDTO.swift
@@ -1,0 +1,15 @@
+//
+//  SearchWeeklyContestRequestDTO.swift
+//  CoreNetwork
+//
+//  Created by ParkJunHyuk on 6/16/25.
+//
+
+import Foundation
+
+public struct SearchWeeklyContestRequestDTO: Encodable {
+    let round: Int
+    let orderCriteria: String
+    let page: Int
+    let pageSize: Int
+}

--- a/Soongan/Core/CoreNetwork/Sources/WeeklyContest/DTO/Response/PostWeeklyContestResponseDTO.swift
+++ b/Soongan/Core/CoreNetwork/Sources/WeeklyContest/DTO/Response/PostWeeklyContestResponseDTO.swift
@@ -1,0 +1,15 @@
+//
+//  PostWeeklyContestResponseDTO.swift
+//  CoreNetwork
+//
+//  Created by ParkJunHyuk on 6/16/25.
+//
+
+import Foundation
+
+public struct PostWeeklyContestResponseDTO: Decodable {
+    let postId: Int
+    let title: String
+    let imageurl: String
+    let registerNickname: String
+}

--- a/Soongan/Core/CoreNetwork/Sources/WeeklyContest/DTO/Response/SearchDetailContestResponseDTO.swift
+++ b/Soongan/Core/CoreNetwork/Sources/WeeklyContest/DTO/Response/SearchDetailContestResponseDTO.swift
@@ -1,0 +1,19 @@
+//
+//  SearchDetailContestResponseDTO.swift
+//  CoreNetwork
+//
+//  Created by ParkJunHyuk on 6/25/25.
+//
+
+import Foundation
+
+public struct SearchDetailContestResponseDTO: Decodable {
+    public let memberId: Int
+    public let postId: Int
+    public let title: String
+    public let imageurl: String
+    public let nickname: String
+    public let likeCount: Int
+    public let isLiked: Bool
+    public let commentCount: Int
+}

--- a/Soongan/Core/CoreNetwork/Sources/WeeklyContest/DTO/Response/SearchDetailHistoriesContestResponseDTO.swift
+++ b/Soongan/Core/CoreNetwork/Sources/WeeklyContest/DTO/Response/SearchDetailHistoriesContestResponseDTO.swift
@@ -1,0 +1,31 @@
+//
+//  SearchDetailHistoriesContestResponseDTO.swift
+//  CoreNetwork
+//
+//  Created by ParkJunHyuk on 6/25/25.
+//
+
+import Foundation
+
+public struct SearchDetailHistoriesContestResponseDTO: Decodable {
+    public let postCount: Int
+    public let firstPrizePost: FirstPostInfo
+    public let otherTop7Posts: [OtherPosts]
+}
+
+public struct FirstPostInfo: Decodable {
+    public let postId: Int
+    public let title: String
+    public let imageUrl: String
+    public let nickname: String
+    public let score: Int
+}
+
+public struct OtherPosts: Decodable {
+    public let postId: Int
+    public let title: String
+    public let imageUrl: String
+    public let nickname: String
+    public let ranking: Int
+    public let score: Int
+}

--- a/Soongan/Core/CoreNetwork/Sources/WeeklyContest/DTO/Response/SearchHistoriesContestResponseDTO.swift
+++ b/Soongan/Core/CoreNetwork/Sources/WeeklyContest/DTO/Response/SearchHistoriesContestResponseDTO.swift
@@ -1,0 +1,22 @@
+//
+//  SearchHistoriesContestResponseDTO.swift
+//  CoreNetwork
+//
+//  Created by ParkJunHyuk on 6/16/25.
+//
+
+import Foundation
+
+public struct SearchHistoriesContestResponseDTO: Decodable {
+    let contests: [SearchHistoriesContestData]
+}
+
+public struct SearchHistoriesContestData: Decodable {
+    let id: Int
+    let round: Int
+    let subject: String
+    let startAt: String
+    let endAt: String
+    let announcedAt: String
+    let thumbnailImageUrl: String
+}

--- a/Soongan/Core/CoreNetwork/Sources/WeeklyContest/DTO/Response/SearchHistoriesContestResponseDTO.swift
+++ b/Soongan/Core/CoreNetwork/Sources/WeeklyContest/DTO/Response/SearchHistoriesContestResponseDTO.swift
@@ -8,15 +8,15 @@
 import Foundation
 
 public struct SearchHistoriesContestResponseDTO: Decodable {
-    let contests: [SearchHistoriesContestData]
+    public let contests: [SearchHistoriesContestData]
 }
 
-public struct SearchHistoriesContestData: Decodable {
-    let id: Int
-    let round: Int
-    let subject: String
-    let startAt: String
-    let endAt: String
-    let announcedAt: String
-    let thumbnailImageUrl: String
+public struct SearchHistoriesContestData: Decodable, Equatable, Hashable {
+    public let id: Int
+    public let round: Int
+    public let subject: String
+    public let startAt: String
+    public let endAt: String
+    public let announcedAt: String
+    public let thumbnailImageUrl: String
 }

--- a/Soongan/Core/CoreNetwork/Sources/WeeklyContest/DTO/Response/SearchMyContestResponseDTO.swift
+++ b/Soongan/Core/CoreNetwork/Sources/WeeklyContest/DTO/Response/SearchMyContestResponseDTO.swift
@@ -1,0 +1,21 @@
+//
+//  SearchMyContestResponseDTO.swift
+//  CoreNetwork
+//
+//  Created by ParkJunHyuk on 6/16/25.
+//
+
+import Foundation
+
+public struct SearchMyContestResponseDTO: Decodable {
+    let postInfo: [SearchMYContestInfoData]
+    let pageInfo: PageInfoData
+}
+
+public struct SearchMYContestInfoData: Decodable {
+    let round: Int
+    let subject: String
+    let postId: Int
+    let imageUrl: String
+    let likeCount: Int
+}

--- a/Soongan/Core/CoreNetwork/Sources/WeeklyContest/DTO/Response/SearchWeeklyContestResponseDTO.swift
+++ b/Soongan/Core/CoreNetwork/Sources/WeeklyContest/DTO/Response/SearchWeeklyContestResponseDTO.swift
@@ -8,21 +8,21 @@
 import Foundation
 
 public struct SearchWeeklyContestResponseDTO: Decodable {
-    let round: Int
-    let subject: String
-    let posts: [PostInfoData]
-    let pageInfo: PageInfoData
+    public let round: Int
+    public let subject: String
+    public let posts: [PostInfoData]
+    public let pageInfo: PageInfoData
 }
 
 public struct PostInfoData: Decodable {
-    let nickname: String
-    let profileImageUrl: String
-    let postId: Int
-    let imageUrl: String
+    public let nickname: String
+    public let profileImageUrl: String
+    public let postId: Int
+    public let imageUrl: String
 }
 
 public struct PageInfoData: Decodable {
-    let page: Int
-    let size: Int
-    let hasNext: Bool
+    public let page: Int
+    public let size: Int
+    public let hasNext: Bool
 }

--- a/Soongan/Core/CoreNetwork/Sources/WeeklyContest/DTO/Response/SearchWeeklyContestResponseDTO.swift
+++ b/Soongan/Core/CoreNetwork/Sources/WeeklyContest/DTO/Response/SearchWeeklyContestResponseDTO.swift
@@ -1,0 +1,28 @@
+//
+//  SearchWeeklyContestResponseDTO.swift
+//  CoreNetwork
+//
+//  Created by ParkJunHyuk on 6/16/25.
+//
+
+import Foundation
+
+public struct SearchWeeklyContestResponseDTO: Decodable {
+    let round: Int
+    let subject: String
+    let posts: [PostInfoData]
+    let pageInfo: PageInfoData
+}
+
+public struct PostInfoData: Decodable {
+    let nickname: String
+    let profileImageUrl: String
+    let postId: Int
+    let imageUrl: String
+}
+
+public struct PageInfoData: Decodable {
+    let page: Int
+    let size: Int
+    let hasNext: Bool
+}

--- a/Soongan/Core/CoreNetwork/Sources/WeeklyContest/WeeklyContestEndpoint.swift
+++ b/Soongan/Core/CoreNetwork/Sources/WeeklyContest/WeeklyContestEndpoint.swift
@@ -1,0 +1,75 @@
+//
+//  WeeklyContestEndpoint.swift
+//  CoreNetwork
+//
+//  Created by ParkJunHyuk on 6/16/25.
+//
+
+import Alamofire
+
+public enum WeeklyContestEndpoint {
+    case getContest(SearchWeeklyContestRequestDTO)
+    case postContest(PostWeeklyContestRequestDTO)
+    case getDetailContest(postId: String)
+    case deleteContest(postId: String)
+    case patchContest(postId: String)
+    case getMyContest(SearchMyContestRequestDTO)
+    case getHistoriesContest
+    case getDetailHistoriesContest(contestId: String)
+}
+
+extension WeeklyContestEndpoint: APIEndpoint {
+    public var basePath: BasePath {
+        return .weeklyContest
+    }
+    
+    public var path: String {
+        switch self {
+        case .getContest, .postContest:
+            return basePath.rawValue + "/posts"
+        case .getDetailContest(let postId), .deleteContest(let postId), .patchContest(let postId):
+            return basePath.rawValue + "/posts/\(postId)"
+        case .getMyContest:
+            return basePath.rawValue + "/posts/my-hisotry"
+        case .getHistoriesContest:
+            return basePath.rawValue + "/histories"
+        case .getDetailHistoriesContest(let contestId):
+            return basePath.rawValue + "/histories/\(contestId)"
+        }
+    }
+    
+    public var method: Alamofire.HTTPMethod {
+        switch self {
+        case .getContest, .getDetailContest, .getMyContest, .getHistoriesContest, .getDetailHistoriesContest:
+            return .get
+        case .postContest:
+            return .post
+        case .deleteContest:
+            return .delete
+        case .patchContest:
+            return .patch
+        }
+    }
+    
+    public var headerType: HeaderType {
+        switch self {
+        case .postContest, .getDetailContest, .deleteContest, .patchContest, .getMyContest:
+            return .accessTokenHeader
+        case .getContest, .getHistoriesContest, .getDetailHistoriesContest:
+            return .defaultHeader
+        }
+    }
+    
+    public var parameters: (any Encodable)? {
+        switch self {
+        case .getContest(let dto):
+            return dto
+        case .postContest(let dto):
+            return dto
+        case .getMyContest(let dto):
+            return dto
+        default:
+            return nil
+        }
+    }
+}

--- a/Soongan/Core/CoreNetwork/Sources/WeeklyContest/WeeklyContestEndpoint.swift
+++ b/Soongan/Core/CoreNetwork/Sources/WeeklyContest/WeeklyContestEndpoint.swift
@@ -6,6 +6,7 @@
 //
 
 import Alamofire
+import Foundation
 
 public enum WeeklyContestEndpoint {
     case getContest(SearchWeeklyContestRequestDTO)
@@ -60,13 +61,20 @@ extension WeeklyContestEndpoint: APIEndpoint {
         }
     }
     
-    public var parameters: (any Encodable)? {
+    public var queryParameters: [URLQueryItem]? {
         switch self {
         case .getContest(let dto):
-            return dto
-        case .postContest(let dto):
-            return dto
+            return dto.toQueryItems()
         case .getMyContest(let dto):
+            return dto.toQueryItems()
+        default:
+            return nil
+        }
+    }
+    
+    public var body: (any Encodable)? {
+        switch self {
+        case .postContest(let dto):
             return dto
         default:
             return nil

--- a/Soongan/DesignSystem/Sources/Component/CircleButton.swift
+++ b/Soongan/DesignSystem/Sources/Component/CircleButton.swift
@@ -43,7 +43,7 @@ public struct CircleButton: View {
             }
             
             Text(type.title)
-                .font(.regualr12)
+                .font(.regular12)
                 .foregroundStyle(Color.black100)
         }
     }

--- a/Soongan/DesignSystem/Sources/Component/CustomSheetView.swift
+++ b/Soongan/DesignSystem/Sources/Component/CustomSheetView.swift
@@ -9,16 +9,18 @@ import SwiftUI
 
 import Shared
 
-import ComposableArchitecture
+//import ComposableArchitecture
 
-public struct CustomSheetView: View {
+public enum NeverOption: Equatable, CaseIterable { }
+
+public struct CustomSheetView<T: Equatable & CaseIterable>: View {
     
     // MARK: - Properties
     
     @Environment(\.dismiss) private var dismiss
     private let type: SheetContentType
     private var action: (() -> Void)? = nil
-    private var optionAction: ((MyprofileOptionType) -> Void)? = nil
+    private var optionAction: ((T) -> Void)? = nil
     
     @State private var inputText = ""
     
@@ -34,7 +36,7 @@ public struct CustomSheetView: View {
     
     public init(
         type: SheetContentType,
-        optionAction: @escaping (MyprofileOptionType) -> Void
+        optionAction: @escaping (T) -> Void
     ) {
         self.type = type
         self.optionAction = optionAction
@@ -52,8 +54,8 @@ public struct CustomSheetView: View {
                     .padding(.top, 40)
                 
             case .postPicture(let name):
-                postPictureContetnSection(name: name, action: {})
-                    .padding(.top, 40)
+                PostPictureContentSectionView(name: name, action: action ?? {})
+                       .padding(.top, 14)
                 
             case .logout:
                 logoutContentSection(action: {})
@@ -66,7 +68,7 @@ public struct CustomSheetView: View {
             case .myprofileOption:
                 mypageOptionContentSection(action: { optionType in
                     guard let optionAction else { return }
-                    optionAction(optionType)
+                    optionAction(optionType as! T)
                 })
                 .padding(.top, 30)
                 
@@ -87,6 +89,14 @@ public struct CustomSheetView: View {
             case .reportComplete:
                 reportCompleteContentSection(action: {})
                     .padding(.top, 40)
+                
+            case .detailContestOption:
+                detailContestOptionSection(action: { optionType in
+                    guard let optionAction else { return }
+                    optionAction(optionType as! T)
+
+                })
+                .padding(.top, 30)
             }
         }
         .frame(maxHeight: .infinity, alignment: .top)
@@ -121,7 +131,7 @@ private extension CustomSheetView {
                 .padding(.bottom, 2)
             
             Text("작품 총 3개 출품 가능")
-                .font(.regualr16)
+                .font(.regular16)
                 .padding(.bottom, 10)
                 .padding(.leading, 16)
             
@@ -130,17 +140,17 @@ private extension CustomSheetView {
                 .padding(.bottom, 4)
             
             Text("투표: 좋아요 개수로 TOP 7 선정")
-                .font(.regualr16)
+                .font(.regular16)
                 .padding(.bottom, 4)
                 .padding(.leading, 16)
             
             Text("기간 : 1달")
-                .font(.regualr16)
+                .font(.regular16)
                 .padding(.bottom, 4)
                 .padding(.leading, 16)
             
             Text("매달 1일 오전 9시 ~ 다음 달 1일 00시")
-                .font(.regualr16)
+                .font(.regular16)
                 .padding(.bottom, 8)
                 .padding(.leading, 16)
             
@@ -149,12 +159,12 @@ private extension CustomSheetView {
                 .padding(.bottom, 4)
             
             Text("1. 직전 회차 참가자")
-                .font(.regualr16)
+                .font(.regular16)
                 .padding(.bottom, 4)
                 .padding(.leading, 16)
             
             Text("2. 업로드 시간을 비교해 더 일찍 참가한 작품")
-                .font(.regualr16)
+                .font(.regular16)
                 .padding(.bottom, 8)
                 .padding(.leading, 16)
             
@@ -163,12 +173,12 @@ private extension CustomSheetView {
                 .padding(.bottom, 4)
             
             Text("최종 1위한 작품은\n앱 접속 시 나오는 화면에 배경 사진으로 사용")
-                .font(.regualr16)
+                .font(.regular16)
                 .padding(.bottom, 4)
                 .padding(.leading, 16)
             
             Text("(차기 콘테스트 종료 시까지)")
-                .font(.regualr16)
+                .font(.regular16)
                 .padding(.leading, 16)
             
             CustomBottomButton(
@@ -185,25 +195,59 @@ private extension CustomSheetView {
         .padding(.horizontal, 38)
     }
     
-    func postPictureContetnSection(name: String, action: @escaping () -> Void) -> some View {
-        VStack(alignment: .leading, spacing: 0) {
-            
+    func postPictureContentSection(name: String, action: @escaping () -> Void) -> some View {
+        @State var isChecked = false
+        
+        return VStack(alignment: .leading, spacing: 0) {
             VStack(alignment: .leading, spacing: 5) {
                 Text("<\(name)>")
                 Text("(으)로 작품을 제출할까요?")
             }
             .padding(.horizontal, 20)
+            .padding(.bottom, 18)
+            
+            HStack(spacing: 0) {
+                Button(action: {
+                    isChecked.toggle()
+                    print("버튼 눌림", isChecked)
+                }) {
+                    ZStack {
+                        Rectangle()
+                            .stroke(Color.black, lineWidth: 2)
+                            .fill(isChecked ? Color.black : Color.clear)
+                            .frame(width: 24, height: 24)
+
+                        if isChecked {
+                            Image.checkIcon
+                                .frame(width: 12, height: 12)
+                        }
+                    }
+                }
+                .padding(.trailing, 16)
+
+                HStack(alignment: .top, spacing: 4) {
+                    Text("*")
+                        .foregroundStyle(DesignSystem.Color.primary)
+                        .offset(y: 2)
+
+                    Text("등록된 순간은 약관에 따라 관리되며,\nTOP 7에 선정된 순간은 역대 콘테스트에 기록됩니다")
+                        .foregroundStyle(DesignSystem.Color.black100)
+                }
+                .font(.regular12)
+            }
+            .padding(.horizontal, 20)
             
             CustomBottomButton(
                 type: .complete,
+                isEnable: $isChecked,
                 action: {
                     action()
                     dismiss()
                 }
             )
-            .padding(.top, 40)
+            .padding(.top, 16)
         }
-        .font(.regualr16)
+        .font(.regular16)
         .foregroundStyle(Color.black)
         .padding(.horizontal, 20)
     }
@@ -244,16 +288,16 @@ private extension CustomSheetView {
         VStack {
             VStack(alignment: .leading, spacing: 15) {
                 Text("정말 회원탈퇴를 하실 건가요?")
-                    .font(.regualr16)
+                    .font(.regular16)
                     .foregroundStyle(Color.black100)
                 
                 Text("회원탈퇴를 위해 아래 입력창에\n'회원탈퇴'를 입력해주세요")
-                    .font(.regualr16)
+                    .font(.regular16)
                     .foregroundStyle(Color.black100)
                 
                 TextField("", text: $inputText,
                           prompt: Text("텍스트를 입력해주세요.").foregroundColor(Color.init(red: 187/255, green: 187/255, blue: 187/255)))
-                    .font(.regualr18)
+                    .font(.regular18)
                     .padding()
                     .frame(height: 48)
                     .tint(.black100)
@@ -282,7 +326,7 @@ private extension CustomSheetView {
     func logoutContentSection(action: @escaping () -> Void) -> some View {
         VStack(alignment: .leading, spacing: 15) {
             Text("정말 로그아웃 하실 건가요?")
-                .font(.regualr16)
+                .font(.regular16)
                 .foregroundStyle(Color.black100)
                 .padding(.horizontal, 20)
             
@@ -312,7 +356,7 @@ private extension CustomSheetView {
                             
                             if !option.subTitle.isEmpty {
                                 Text(option.subTitle)
-                                    .font(.regualr12)
+                                    .font(.regular12)
                                     .foregroundStyle(Color.black100)
                             }
                         }
@@ -323,6 +367,38 @@ private extension CustomSheetView {
                     .tint(.primary)
                     
                     if option != AlaramSettingOptionType.allCases.last {
+                        Rectangle()
+                            .fill(Color(red: 187/255, green: 187/255, blue: 187/255))
+                            .frame(maxWidth: .infinity)
+                            .frame(height: 0.7)
+                            .padding(.horizontal, 24)
+                    }
+                }
+            }
+        }
+    }
+    
+    func detailContestOptionSection(action: @escaping (DetailContestOptionType) -> Void) -> some View {
+        VStack(spacing: 0) {
+            ForEach(DetailContestOptionType.allCases, id: \.self) { option in
+                VStack(spacing: 0) {
+                    Button(action: {
+                        action(option)
+                    }) {
+                        HStack(alignment: .center) {
+                            Text(option.title)
+                                .font(.semibold16)
+                                .foregroundStyle(Color.black100)
+                            
+                            Spacer()
+                            
+                            option.rightImage
+                        }
+                        .frame(height: 56)
+                        .padding(.horizontal, 40)
+                    }
+                    
+                    if option != DetailContestOptionType.allCases.last {
                         Rectangle()
                             .fill(Color(red: 187/255, green: 187/255, blue: 187/255))
                             .frame(maxWidth: .infinity)
@@ -366,18 +442,18 @@ private extension CustomSheetView {
         VStack(spacing: 0) {
             VStack(alignment: .leading, spacing: 4) {
                 Text("이 댓글을")
-                    .font(.regualr16)
+                    .font(.regular16)
                 
                 HStack(spacing: 0) {
                     Text(reportType.title)
                         .font(.bold16)
                     
                     Text("(으)로")
-                        .font(.regualr16)
+                        .font(.regular16)
                 }
                 
                 Text("정말 신고하겠습니까?")
-                    .font(.regualr16)
+                    .font(.regular16)
             }
             .padding(.horizontal, 4)
             .foregroundStyle(Color.black100)
@@ -406,7 +482,7 @@ private extension CustomSheetView {
                 Text("감사합니다")
                 
             }
-            .font(.regualr16)
+            .font(.regular16)
             .foregroundStyle(Color.black100)
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.horizontal, 4)
@@ -426,6 +502,68 @@ private extension CustomSheetView {
 
 // MARK: - Preview
 
-#Preview {
-    CustomSheetView(type: .contestReport, action: {})
+//#Preview {
+//    CustomSheetView(type: .postPicture(name: "테스트"), action: {})
+//}
+
+
+struct PostPictureContentSectionView: View {
+    let name: String
+    @Environment(\.dismiss) private var dismiss
+    @State var isChecked: Bool = false
+    let action: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            VStack(alignment: .leading, spacing: 5) {
+                Text("<\(name)>")
+                Text("(으)로 작품을 제출할까요?")
+            }
+            .padding(.horizontal, 20)
+            .padding(.bottom, 18)
+            
+            HStack(spacing: 0) {
+                Button(action: {
+                    isChecked.toggle()
+                    print("버튼 눌림", isChecked)
+                }) {
+                    ZStack {
+                        Rectangle()
+                            .stroke(Color.black, lineWidth: 2)
+                            .fill(isChecked ? Color.black : Color.clear)
+                            .frame(width: 20, height: 240)
+
+                        if isChecked {
+                            Image.checkIcon
+                                .frame(width: 12, height: 12)
+                        }
+                    }
+                }
+                .padding(.trailing, 16)
+
+                HStack(alignment: .top, spacing: 4) {
+                    Text("*")
+                        .foregroundStyle(DesignSystem.Color.primary)
+
+                    Text("등록된 순간은 약관에 따라 관리되며,\nTOP 7에 선정된 순간은 역대 콘테스트에 기록됩니다")
+                        .foregroundStyle(DesignSystem.Color.black100)
+                }
+                .font(.regular12)
+            }
+            .padding(.horizontal, 20)
+            
+            CustomBottomButton(
+                type: .complete,
+                isEnable: $isChecked,
+                action: {
+                    action()
+                    dismiss()
+                }
+            )
+            .padding(.top, 16)
+        }
+        .font(.regular16)
+        .foregroundStyle(Color.black)
+        .padding(.horizontal, 20)
+    }
 }

--- a/Soongan/DesignSystem/Sources/Component/CustomTextFieldView.swift
+++ b/Soongan/DesignSystem/Sources/Component/CustomTextFieldView.swift
@@ -44,7 +44,7 @@ public struct CustomTextFieldView: View {
             ? (isFocused.wrappedValue ? state.borderColor : .clear)
             : DesignSystem.Color.black100
         
-        let titleFont: Font = (type == .birthday || type == .nickname) ? .regualr16 : .regualr8
+        let titleFont: Font = (type == .birthday || type == .nickname) ? .regular16 : .regular8
         
         VStack(alignment: .leading, spacing: 0) {
             Text(type.title)
@@ -55,7 +55,7 @@ public struct CustomTextFieldView: View {
             
             TextField("", text: $text, prompt: Text(type.placeholder).foregroundColor(.black60))
                 .focused(isFocused)
-                .font(.regualr18)
+                .font(.regular18)
                 .padding()
                 .tint(.black100)
                 .background(

--- a/Soongan/DesignSystem/Sources/Component/TopTabButtonView.swift
+++ b/Soongan/DesignSystem/Sources/Component/TopTabButtonView.swift
@@ -34,7 +34,7 @@ public struct TopTabButtonView: View {
             Button(action: action) {
                 Text(title)
                     .foregroundColor(isSelected ? DesignSystem.Color.black100 : .gray)
-                    .font(isSelected ? .bold12 : .regualr12)
+                    .font(isSelected ? .bold12 : .regular12)
             }
             .frame(width: 100, height: 24)
             .padding(.bottom, 12)

--- a/Soongan/DesignSystem/Sources/Enum/SheetContentType.swift
+++ b/Soongan/DesignSystem/Sources/Enum/SheetContentType.swift
@@ -18,6 +18,7 @@ public enum SheetContentType: Identifiable, Equatable {
     case contestReport
     case spam
     case reportComplete
+    case detailContestOption
     
     public var id: String {
         switch self {
@@ -31,16 +32,17 @@ public enum SheetContentType: Identifiable, Equatable {
         case .contestReport: return "contestReport"
         case .spam: return "spam"
         case .reportComplete: return "reportComplete"
+        case .detailContestOption: return "detailContestOption"
         }
     }
     
     var title: String {
         switch self {
         case .contestInfo: return "대회정보"
-        case .postPicture: return "제목확인"
+        case .postPicture: return "제목 확인"
         case .logout: return "로그아웃"
         case .withdraw, .completeWithdraw: return "회원탈퇴"
-        case .myprofileOption: return ""
+        case .myprofileOption, .detailContestOption: return ""
         case .alarmSetting: return "푸시 알림 설정"
         case .contestReport, .reportComplete, .spam: return "신고"
         }
@@ -58,6 +60,7 @@ public enum SheetContentType: Identifiable, Equatable {
         case .contestReport: return [.height(432)]
         case .spam: return [.height(288)]
         case .reportComplete: return [.height(456)]
+        case .detailContestOption: return [.height(240)]
         }
     }
 }
@@ -126,7 +129,6 @@ public enum AlaramSettingOptionType: Equatable, CaseIterable {
     
     var title: String {
         switch self {
-            
         case .allAlarm: return "전체 알림"
         case .contestAlarm: return "대회 알림"
         case .activeAlarm: return "활동 알림"
@@ -140,6 +142,28 @@ public enum AlaramSettingOptionType: Equatable, CaseIterable {
         case .contestAlarm: return "대회 시작, 최종 투표 시작, 결과 발표 등"
         case .activeAlarm: return "(대)댓글 작성, 신고 접수 및 결과 안내 등"
         case .noticeAlarm: return "공지사항 알림"
+        }
+    }
+}
+
+public enum DetailContestOptionType: Equatable, CaseIterable {
+    case edit
+    case delete
+    case report
+    
+    var title: String {
+        switch self {
+        case .edit: return "수정하기"
+        case .delete: return "삭제하기"
+        case .report: return "신고하기"
+        }
+    }
+    
+    var rightImage: Image {
+        switch self {
+        case .edit: return .editPost
+        case .delete: return .deletePost
+        case .report: return .reportCard
         }
     }
 }

--- a/Soongan/DesignSystem/Sources/Extension/Font+Soongan.swift
+++ b/Soongan/DesignSystem/Sources/Extension/Font+Soongan.swift
@@ -73,23 +73,23 @@ public extension Font {
         return ResourceFontFamily.Pretendard.medium.swiftUIFont(size: 12)
     }
     
-    static var regualr8: Font {
+    static var regular8: Font {
         return ResourceFontFamily.Pretendard.regular.swiftUIFont(size: 8)
     }
     
-    static var regualr12: Font {
+    static var regular12: Font {
         return ResourceFontFamily.Pretendard.regular.swiftUIFont(size: 12)
     }
     
-    static var regualr14: Font {
+    static var regular14: Font {
         return ResourceFontFamily.Pretendard.regular.swiftUIFont(size: 14)
     }
     
-    static var regualr16: Font {
+    static var regular16: Font {
         return ResourceFontFamily.Pretendard.regular.swiftUIFont(size: 16)
     }
     
-    static var regualr18: Font {
+    static var regular18: Font {
         return ResourceFontFamily.Pretendard.regular.swiftUIFont(size: 18)
     }
     

--- a/Soongan/DesignSystem/Sources/Image/SoonganImage.swift
+++ b/Soongan/DesignSystem/Sources/Image/SoonganImage.swift
@@ -52,6 +52,10 @@ public extension Image {
     static var addPlus: Image {
         return ResourceAsset.Image.addPlusImage.swiftUIImage
     }
+    
+    static var checkIcon: Image {
+        return ResourceAsset.Image.checkIcon.swiftUIImage
+    }
 }
 
 // MARK: - Contest Image

--- a/Soongan/Feature/AllTimeContestFeature/Project.swift
+++ b/Soongan/Feature/AllTimeContestFeature/Project.swift
@@ -21,6 +21,7 @@ let project = Project(
             dependencies: [
                 .external(name: "ComposableArchitecture"),
                 .project(target: "DesignSystem", path: "../../DesignSystem"),
+                .project(target: "CoreNetwork", path: "../../Core/CoreNetwork"),
                 .project(target: "Shared", path: "../../Shared")
             ]
         )

--- a/Soongan/Feature/AllTimeContestFeature/Project.swift
+++ b/Soongan/Feature/AllTimeContestFeature/Project.swift
@@ -12,7 +12,7 @@ let project = Project(
         .target(
             name: "AllTimeContestFeature",
             destinations: .iOS,
-            product: .framework,
+            product: .staticFramework,
             bundleId: "com.captures.AllTimeContestFeature.Soongan",
             deploymentTargets: .iOS("17.0"),
             infoPlist: .default,

--- a/Soongan/Feature/AllTimeContestFeature/Sources/Logic/AllTimeContestFeature.swift
+++ b/Soongan/Feature/AllTimeContestFeature/Sources/Logic/AllTimeContestFeature.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 
+import CoreNetwork
 import DesignSystem
 import Shared
 
@@ -28,7 +29,8 @@ public struct AllTimeContestFeature {
     public struct State: Equatable {
         var path = StackState<AllTimeContestPath.State>()
         
-        var allTimeContestListData = [AllTimeContestModel(title: "평화", backgroundImageURL: ""), AllTimeContestModel(title: "평화2", backgroundImageURL: ""), AllTimeContestModel(title: "평화3", backgroundImageURL: "")]
+        var allTimeDictionaryData = [Int: SearchHistoriesContestData]()
+        var allTimeContestListData = [AllTimeContestModel]()
         
         // CustomTabBar 가시성
         public var isTabBarVisible: Bool {
@@ -49,8 +51,10 @@ public struct AllTimeContestFeature {
         
         case binding(BindingAction<State>)
     
+        case onAppear
+        case historyContestSuccessResponse(SearchHistoriesContestResponseDTO)
         
-        case contestListTapped
+        case contestListTapped(id: Int)
 //        case presentSheet
 //        case chagneContestIndex
 //        case dismissContestSheet(Bool)
@@ -66,6 +70,27 @@ public struct AllTimeContestFeature {
         Reduce { state, action in
             switch action {
                 
+            case .onAppear:
+                return .run { send in
+                    let result: Result<SearchHistoriesContestResponseDTO, NetworkError> = await NetworkManager.shared.request(WeeklyContestEndpoint.getHistoriesContest)
+                    
+                    switch result {
+                    case .success(let responseResult):
+                        return await send(.historyContestSuccessResponse(responseResult))
+                    case .failure(let error):
+                        print(error.localizedDescription)
+                    }
+                }
+                
+            case .historyContestSuccessResponse(let response):
+                response.contests.forEach {
+                    state.allTimeDictionaryData[$0.id] = $0
+                }
+                
+                state.allTimeContestListData = convertAllTimeContestModel(response)
+                
+                return .none
+                
             case let .path(.element(id: _, action: action)):
                 switch action {
                 case .detailContest(.backButtonTapped):
@@ -75,9 +100,21 @@ public struct AllTimeContestFeature {
                     return .none
                 }
                 
-            case .contestListTapped:
-                state.path.append(.detailContest(DetailContestFeature.State()))
+            case .contestListTapped(let id):
+                if let data = state.allTimeDictionaryData[id] {
+                    let contestInfo = DetailContestInfoModel(
+                        id: id,
+                        round: data.round,
+                        subject: data.subject,
+                        startAt: data.startAt,
+                        endAt: data.endAt
+                    )
+                    
+                    state.path.append(.detailContest(DetailContestFeature.State(contestInfoData: contestInfo)))
+                }
+                
                 return .none
+                
 //            case let .path(.element(id: _, action: action)):
 //                switch action {
 //                case .contestDetail(.backButtonTapped):
@@ -121,5 +158,14 @@ public struct AllTimeContestFeature {
             }
         }
         .forEach(\.path, action: \.path)
+    }
+}
+
+
+private extension AllTimeContestFeature {
+    func convertAllTimeContestModel(_ data: SearchHistoriesContestResponseDTO) -> [AllTimeContestModel] {
+        return data.contests.map {
+            AllTimeContestModel(id: $0.id, title: $0.subject, backgroundImageURL: $0.thumbnailImageUrl)
+        }
     }
 }

--- a/Soongan/Feature/AllTimeContestFeature/Sources/Logic/DetailContestFeature.swift
+++ b/Soongan/Feature/AllTimeContestFeature/Sources/Logic/DetailContestFeature.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 
+import CoreNetwork
 import DesignSystem
 import Shared
 
@@ -19,8 +20,11 @@ public struct DetailContestFeature {
     
     @ObservableState
     public struct State: Equatable {
+        var contestInfoData: DetailContestInfoModel
         
-        
+        var contestCount: Int?
+        var firstPostData: DetailHistoryFirstPostModel?
+        var otherPostData: [DetailHistoryOtherPostModel]?
     }
     
     // MARK: - Init
@@ -32,6 +36,9 @@ public struct DetailContestFeature {
     public enum Action: BindableAction {
         case binding(BindingAction<State>)
         
+        case onAppear
+        case detailHistoryContestSuccessResponse(SearchDetailHistoriesContestResponseDTO)
+        
         case backButtonTapped
     }
     
@@ -41,9 +48,56 @@ public struct DetailContestFeature {
         Reduce { state, action in
             switch action {
      
+            case .onAppear:
+                let contestId = state.contestInfoData.id
+                
+                return .run { send in
+                    let result: Result<SearchDetailHistoriesContestResponseDTO, NetworkError> = await NetworkManager.shared.request(WeeklyContestEndpoint.getDetailHistoriesContest(contestId: String(contestId)))
+                    
+                    switch result {
+                    case .success(let responseResult):
+                        return await send(.detailHistoryContestSuccessResponse(responseResult))
+                    case .failure(let error):
+                        print(error.localizedDescription)
+                    }
+                }
+                
+            case .detailHistoryContestSuccessResponse(let response):
+                state.contestCount = response.postCount
+                state.firstPostData = convertFirstModel(response.firstPrizePost)
+                state.otherPostData = convertOtherModel(response.otherTop7Posts)
+                
+                return .none
+                
             default:
                 return .none
             }
+        }
+    }
+}
+
+// MARK: - Private function Extension
+
+private extension DetailContestFeature {
+    func convertFirstModel(_ data: FirstPostInfo) -> DetailHistoryFirstPostModel {
+        return DetailHistoryFirstPostModel(
+            id: data.postId,
+            nickName: data.nickname,
+            postTitle: data.title,
+            likeCount: data.score,
+            imageUrl: data.imageUrl
+        )
+    }
+    
+    func convertOtherModel(_ data: [OtherPosts]) -> [DetailHistoryOtherPostModel]  {
+        return data.map {
+            DetailHistoryOtherPostModel(
+                id: $0.postId,
+                nickName: $0.nickname,
+                likeCount: $0.score,
+                imageUrl: $0.imageUrl,
+                ranking: $0.ranking
+            )
         }
     }
 }

--- a/Soongan/Feature/AllTimeContestFeature/Sources/Model/AllTimeContestModel.swift
+++ b/Soongan/Feature/AllTimeContestFeature/Sources/Model/AllTimeContestModel.swift
@@ -7,7 +7,8 @@
 
 import Foundation
 
-struct AllTimeContestModel: Equatable, Hashable {
+struct AllTimeContestModel: Identifiable, Equatable, Hashable {
+    let id: Int
     let title: String
     let backgroundImageURL: String
 }

--- a/Soongan/Feature/AllTimeContestFeature/Sources/Model/DetailContestModel.swift
+++ b/Soongan/Feature/AllTimeContestFeature/Sources/Model/DetailContestModel.swift
@@ -1,0 +1,16 @@
+//
+//  DetailContestModel.swift
+//  AllTimeContestFeature
+//
+//  Created by ParkJunHyuk on 6/25/25.
+//
+
+import Foundation
+
+struct DetailContestInfoModel: Equatable, Hashable {
+    let id: Int
+    let round: Int
+    let subject: String
+    let startAt: String
+    let endAt: String
+}

--- a/Soongan/Feature/AllTimeContestFeature/Sources/Model/DetailHistoryFirstPostModel.swift
+++ b/Soongan/Feature/AllTimeContestFeature/Sources/Model/DetailHistoryFirstPostModel.swift
@@ -1,0 +1,16 @@
+//
+//  DetailHistoryFirstPostModel.swift
+//  AllTimeContestFeature
+//
+//  Created by ParkJunHyuk on 6/25/25.
+//
+
+import Foundation
+
+struct DetailHistoryFirstPostModel: Identifiable, Equatable, Hashable {
+    let id: Int
+    let nickName: String
+    let postTitle: String
+    let likeCount: Int
+    let imageUrl: String
+}

--- a/Soongan/Feature/AllTimeContestFeature/Sources/Model/DetailHistoryOtherPostModel.swift
+++ b/Soongan/Feature/AllTimeContestFeature/Sources/Model/DetailHistoryOtherPostModel.swift
@@ -1,0 +1,16 @@
+//
+//  DetailHistoryOtherPostModel.swift
+//  AllTimeContestFeature
+//
+//  Created by ParkJunHyuk on 6/25/25.
+//
+
+import Foundation
+
+struct DetailHistoryOtherPostModel: Identifiable, Equatable, Hashable {
+    let id: Int
+    let nickName: String
+    let likeCount: Int
+    let imageUrl: String
+    let ranking: Int
+}

--- a/Soongan/Feature/AllTimeContestFeature/Sources/View/AllTimeContestView.swift
+++ b/Soongan/Feature/AllTimeContestFeature/Sources/View/AllTimeContestView.swift
@@ -44,7 +44,7 @@ public struct AllTimeContestView: View {
                             LazyVStack(spacing: 12) {
                                 ForEach(store.allTimeContestListData, id: \.self) { contestData in
                                     contestListView(data: contestData) {
-                                        store.send(.contestListTapped)
+                                        store.send(.contestListTapped(id: contestData.id))
                                     }
                                 }
                             }
@@ -63,6 +63,9 @@ public struct AllTimeContestView: View {
                         Spacer(minLength: 350)
                     }
                 }
+            }
+            .onAppear {
+                store.send(.onAppear)
             }
             .toolbar(.hidden, for: .tabBar)
         } destination: { store in

--- a/Soongan/Feature/AllTimeContestFeature/Sources/View/DetailContestView.swift
+++ b/Soongan/Feature/AllTimeContestFeature/Sources/View/DetailContestView.swift
@@ -43,7 +43,6 @@ struct DetailContestView: View {
             
             ScrollView {
                 VStack(spacing: 0) {
-                    
                     Image.dumy6
                         .resizable()
                         .aspectRatio(contentMode: .fit)
@@ -129,18 +128,17 @@ struct DetailContestView: View {
     
     func contestTitleSection() -> some View {
         VStack(spacing: 0) {
-            Text("평화 (1회차)")
+            Text("\(store.contestInfoData.subject) (\(store.contestInfoData.round)회차")
                 .font(.semibold20)
                 .foregroundColor(DesignSystem.Color.black100)
                 .padding(.bottom, 20)
             
-            Text("2025.01.17 - 2025.01.20")
+            Text("\(store.contestInfoData.startAt) - \(store.contestInfoData.endAt)")
                 .font(.semibold14)
                 .foregroundColor(DesignSystem.Color.black100)
                 .padding(.bottom, 8)
             
-            
-            Text("총 참여작품 수 : 30")
+            Text("총 참여작품 수 : \(store.contestCount)")
                 .font(.semibold14)
                 .foregroundColor(DesignSystem.Color.black100)
         }
@@ -149,13 +147,13 @@ struct DetailContestView: View {
 
 // MARK: - Preview
 
-#Preview {
-    NavigationStack {
-        DetailContestView(
-            store: Store(initialState:
-                            DetailContestFeature.State()) {
-                                DetailContestFeature()
-                            }
-        )
-    }
-}
+//#Preview {
+//    NavigationStack {
+//        DetailContestView(
+//            store: Store(initialState:
+//                            DetailContestFeature.State()) {
+//                                DetailContestFeature()
+//                            }
+//        )
+//    }
+//}

--- a/Soongan/Feature/AuthFeature/Project.swift
+++ b/Soongan/Feature/AuthFeature/Project.swift
@@ -20,7 +20,10 @@ let project = Project(
             resources: [],
             dependencies: [
                 .external(name: "ComposableArchitecture"),
-                .project(target: "DesignSystem", path: "../../DesignSystem")
+                .project(target: "DesignSystem", path: "../../DesignSystem"),
+                .project(target: "CoreKakaoLogin", path: "../../Core/CoreKakaoLogin"),
+                .project(target: "CoreAppleLogin", path: "../../Core/CoreAppleLogin"),
+                .project(target: "CoreNetwork", path: "../../Core/CoreNetwork")
             ]
         )
     ]

--- a/Soongan/Feature/AuthFeature/Project.swift
+++ b/Soongan/Feature/AuthFeature/Project.swift
@@ -12,7 +12,7 @@ let project = Project(
         .target(
             name: "AuthFeature",
             destinations: .iOS,
-            product: .framework,
+            product: .staticFramework,
             bundleId: "com.captures.AuthFeature.Soongan",
             deploymentTargets: .iOS("17.0"),
             infoPlist: .default,

--- a/Soongan/Feature/AuthFeature/Sources/Logic/LoginFeature.swift
+++ b/Soongan/Feature/AuthFeature/Sources/Logic/LoginFeature.swift
@@ -69,7 +69,7 @@ public struct LoginFeature {
         case skippLoginButtonTapped
         case termsOfUseButtonTapped
         
-        // Delegate - LoginFeature -> AppFeature 
+        // Delegate - LoginFeature -> AppFeature
         case delegate(Delegate)
         
         public enum Delegate {
@@ -91,8 +91,8 @@ public struct LoginFeature {
             case .appleButtonTapped:
                 return .run { send in
                     do {
-                        let idToken = try await appleLoginService.login()
-                        await send(.socialLoginSuccessResponse(type: .kakao, token: idToken))
+                        let oauthToken = try await appleLoginService.login()
+                        await send(.socialLoginSuccessResponse(type: .apple, token: oauthToken))
                     } catch {
                         await send(.socialLoginFailureResponse(error))
                     }
@@ -101,8 +101,8 @@ public struct LoginFeature {
             case .kakaoButtonTapped:
                 return .run { send in
                     do {
-                        let oauthToken = try await kakaoLoginService.login()
-                        await send(.socialLoginSuccessResponse(type: .apple, token: oauthToken))
+                        let idToken = try await kakaoLoginService.login()
+                        await send(.socialLoginSuccessResponse(type: .kakao, token: idToken))
                     } catch {
                         await send(.socialLoginFailureResponse(error))
                     }
@@ -124,6 +124,9 @@ public struct LoginFeature {
                     
                     switch result {
                     case .success(let authedResult):
+                        KeychainManager.shared.save(key: .accessToken, value: authedResult.accessToken)
+                        KeychainManager.shared.save(key: .refreshToken, value: authedResult.refreshToken)
+                        
                         await send(.loginSuccess)
                         
                     case .failure(let error):
@@ -153,10 +156,14 @@ public struct LoginFeature {
             case .path(.element(id: _, action: .signup(.delegate(.didCompleteSignup(let nickname))))):
                 state.path.append(.signupSuccess(SignupSuccessFeature.State(nickname: nickname)))
                 return .none
-                
-            case .path(.element(id: _, action: .signup(.showSignupView))):
-                state.path.append(.signup(SignupFeature.State()))
-                return .none
+            
+            case .path(.element(id: _, action: .signupSuccess(.delegate(.showMainTab)))):
+                print("LoginFeature 로 데이터 옴")
+                return .send(.delegate(.loginSuccess))
+//            case .path(.element(id: _, action: .signupSuccess(T##SignupSuccessFeature.Action)))
+//            case .path(.element(id: _, action: .signup(.showSignupView))):
+//                state.path.append(.signup(SignupFeature.State()))
+//                return .none
                 
             case .path(.element(id: _, action: .signup(.backButtonTapped))):
                 state.path.removeLast()

--- a/Soongan/Feature/AuthFeature/Sources/Logic/LoginFeature.swift
+++ b/Soongan/Feature/AuthFeature/Sources/Logic/LoginFeature.swift
@@ -7,10 +7,19 @@
 
 import SwiftUI
 
+import CoreAppleLogin
+import CoreKakaoLogin
+import CoreKeyChain
+import CoreNetwork
 import DesignSystem
 import Shared
 
 import ComposableArchitecture
+
+public enum LoginType: String {
+    case kakao = "KAKAO"
+    case apple = "APPLE"
+}
 
 @Reducer
 public struct LoginFeature {
@@ -28,6 +37,7 @@ public struct LoginFeature {
     @ObservableState
     public struct State: Equatable {
         var path = StackState<LoginPath.State>()
+        var errorMessage: String = ""
         
         public init() {}
     }
@@ -35,6 +45,11 @@ public struct LoginFeature {
     // MARK: - Init
     
     public init() {}
+    
+    // MARK: - Dependency
+    
+    @Dependency(\.appleLoginService) var appleLoginService
+    @Dependency(\.kakaoLoginService) var kakaoLoginService
     
     // MARK: - Action
     
@@ -44,6 +59,13 @@ public struct LoginFeature {
         case binding(BindingAction<State>)
         case kakaoButtonTapped
         case appleButtonTapped
+        
+        case socialLoginSuccessResponse(type: LoginType, token: String)
+        case socialLoginFailureResponse(Error)
+        
+        case loginSuccess
+        case loginFailure(Error)
+
         case skippLoginButtonTapped
         case termsOfUseButtonTapped
         
@@ -67,13 +89,56 @@ public struct LoginFeature {
                 return .none
                 
             case .appleButtonTapped:
-                state.path.append(.signup(SignupFeature.State()))
-                return .none
+                return .run { send in
+                    do {
+                        let idToken = try await appleLoginService.login()
+                        await send(.socialLoginSuccessResponse(type: .kakao, token: idToken))
+                    } catch {
+                        await send(.socialLoginFailureResponse(error))
+                    }
+                }
                 
             case .kakaoButtonTapped:
+                return .run { send in
+                    do {
+                        let oauthToken = try await kakaoLoginService.login()
+                        await send(.socialLoginSuccessResponse(type: .apple, token: oauthToken))
+                    } catch {
+                        await send(.socialLoginFailureResponse(error))
+                    }
+                }
+                
+            case let .socialLoginSuccessResponse(type, token):
+                return .run { send in
+                    guard let fcmToken = KeychainManager.shared.load(key: .fcmToken) else { return }
+
+                    let result: Result<AuthedResponseDTO, NetworkError> = await NetworkManager.shared.request(
+                        AuthEndpoint.postLogin(
+                            LoginRequestDTO(
+                                provider: type.rawValue,
+                                idToken: token,
+                                fcmToken: fcmToken
+                            )
+                        )
+                    )
+                    
+                    switch result {
+                    case .success(let authedResult):
+                        await send(.loginSuccess)
+                        
+                    case .failure(let error):
+                        await send(.loginFailure(error))
+                    }
+                }
+                
+            case .loginSuccess:
                 state.path.append(.signup(SignupFeature.State()))
                 return .none
                 
+            case .loginFailure(let error):
+                state.errorMessage = "로그인 실패: \(error.localizedDescription)"
+                return .none
+
             case .termsOfUseButtonTapped:
                 // TODO: - 이용 약관 웹 페이지
                 return .none
@@ -99,11 +164,31 @@ public struct LoginFeature {
 
             case .path:
                 return .none
-
+                
             default:
                 return .none
             }
         }
         .forEach(\.path, action: \.path)
+    }
+}
+
+private struct AppleLoginServiceKey: DependencyKey {
+    static let liveValue: any AppleLoginServiceProtocol = AppleLoginService.shared
+}
+
+private struct KakaoLoginServiceKey: DependencyKey {
+    static let liveValue: any KakaoLoginServiceProtocol = KakaoLoginService.shared
+}
+
+public extension DependencyValues {
+    var appleLoginService: any AppleLoginServiceProtocol {
+        get { self[AppleLoginServiceKey.self] }
+        set { self[AppleLoginServiceKey.self] = newValue }
+    }
+    
+    var kakaoLoginService: any KakaoLoginServiceProtocol {
+        get { self[KakaoLoginServiceKey.self] }
+        set { self[KakaoLoginServiceKey.self] = newValue }
     }
 }

--- a/Soongan/Feature/AuthFeature/Sources/Logic/SignupFeature.swift
+++ b/Soongan/Feature/AuthFeature/Sources/Logic/SignupFeature.swift
@@ -110,10 +110,10 @@ public struct SignupFeature {
                         let result: Result<Bool, NetworkError> = await NetworkManager.shared.request(MemberEndpoint.getCheckNickname(dto))
                         
                         switch result {
-                        case .success(let nickNameResult):
+                        case .success:
                             await send(.checkNicknameResult)
                             
-                        case .failure(let error):
+                        case .failure:
                             await send(.nickNameError)
                         }
                     }
@@ -131,10 +131,10 @@ public struct SignupFeature {
                             )
 
                             switch result {
-                            case .success(let result):
+                            case .success:
                                 await send(.editBirthDayResult)
                                 
-                            case .failure(let error):
+                            case .failure:
                                 await send(.birhDayError)
                             }
                         }
@@ -157,6 +157,7 @@ public struct SignupFeature {
                 return .none
                 
             case .birhDayError:
+                state.birthdayState = .error(message: .condition(type: .birthday))
                 
                 return .none
                 

--- a/Soongan/Feature/AuthFeature/Sources/Logic/SignupFeature.swift
+++ b/Soongan/Feature/AuthFeature/Sources/Logic/SignupFeature.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 
+import CoreNetwork
 import DesignSystem
 import Shared
 
@@ -46,6 +47,12 @@ public struct SignupFeature {
         case nextButtonTapped
         case showSignupView
         case backButtonTapped
+        
+        case checkNicknameResult
+        case editBirthDayResult
+        
+        case nickNameError
+        case birhDayError
         
         // Delegate - SignupFeature -> LoginFeature
         case delegate(Delegate)
@@ -97,20 +104,59 @@ public struct SignupFeature {
             case .nextButtonTapped:
                 switch state.signupState {
                 case .inputNickname:
-                    state.signupState = .inputBirthday
-                    state.isButtonEnabled = false
+                    let dto = CheckNickNameRequestDTO(nickname: state.nickname)
                     
+                    return .run { send in
+                        let result: Result<Bool, NetworkError> = await NetworkManager.shared.request(MemberEndpoint.getCheckNickname(dto))
+                        
+                        switch result {
+                        case .success(let nickNameResult):
+                            await send(.checkNicknameResult)
+                            
+                        case .failure(let error):
+                            await send(.nickNameError)
+                        }
+                    }
                 case .inputBirthday:
                     if birthdayValidationState(state.birthday) {
-                        // TODO: - 다음화면으로 진행
-                        print("SignupFeature 로 데이터 옴")
-                        return .send(.delegate(.didCompleteSignup(nickname: state.nickname)))
-                        
+                        guard let birthdayToInt = Int(state.birthday) else {
+                            return .send(.editBirthDayResult)
+                        }
+
+                        let dto = EditMyBirthYearRequestDTO(birthYear: birthdayToInt)
+
+                        return .run { send in
+                            let result: Result<EditMyBirthYearResponseDTO, NetworkError> = await NetworkManager.shared.request(
+                                MemberEndpoint.patchBirthYear(dto)
+                            )
+
+                            switch result {
+                            case .success(let result):
+                                await send(.editBirthDayResult)
+                                
+                            case .failure(let error):
+                                await send(.birhDayError)
+                            }
+                        }
                     } else {
-                        // TODO: - 잘못된 기입
-                        state.birthdayState = .error(message: .condition(type: .birthday))
+                        return .send(.birhDayError)
                     }
                 }
+                
+            case .checkNicknameResult:
+                state.signupState = .inputBirthday
+                state.isButtonEnabled = false
+                
+                return .none
+                
+            case .editBirthDayResult:
+                return .send(.delegate(.didCompleteSignup(nickname: state.nickname)))
+                
+            case .nickNameError:
+                
+                return .none
+                
+            case .birhDayError:
                 
                 return .none
                 

--- a/Soongan/Feature/AuthFeature/Sources/Logic/SignupSuccessFeature.swift
+++ b/Soongan/Feature/AuthFeature/Sources/Logic/SignupSuccessFeature.swift
@@ -30,6 +30,12 @@ public struct SignupSuccessFeature {
     
     public enum Action {
         case onAppear
+        
+        case delegate(Delegate)
+        
+        public enum Delegate {
+            case showMainTab
+        }
     }
     
     // MARK: - Body
@@ -38,7 +44,13 @@ public struct SignupSuccessFeature {
         Reduce { state, action in
             switch action {
             case .onAppear:
-                print("Appear")
+                return .run { send in
+                    try await Task.sleep(for: .seconds(1))
+                    print("SignupSuccessFeature 로 데이터 옴")
+                    await send(.delegate(.showMainTab))
+                }
+
+            case .delegate(_):
                 return .none
             }
         }

--- a/Soongan/Feature/AuthFeature/Sources/View/SignupSuccessView.swift
+++ b/Soongan/Feature/AuthFeature/Sources/View/SignupSuccessView.swift
@@ -39,6 +39,9 @@ public struct SignupSuccessView: View {
             .font(.semibold36)
             .foregroundStyle(Color.textFieldBackground)
         }
+        .onAppear {
+            store.send(.onAppear)
+        }
         .navigationBarBackButtonHidden(true)
     }
 }

--- a/Soongan/Feature/ContestFeature/Project.swift
+++ b/Soongan/Feature/ContestFeature/Project.swift
@@ -12,7 +12,7 @@ let project = Project(
         .target(
             name: "ContestFeature",
             destinations: .iOS,
-            product: .framework,
+            product: .staticFramework,
             bundleId: "com.captures.ContestFeature.Soongan",
             deploymentTargets: .iOS("17.0"),
             infoPlist: .default,

--- a/Soongan/Feature/ContestFeature/Project.swift
+++ b/Soongan/Feature/ContestFeature/Project.swift
@@ -20,7 +20,8 @@ let project = Project(
             resources: [],
             dependencies: [
                 .external(name: "ComposableArchitecture"),
-                .project(target: "DesignSystem", path: "../../DesignSystem")
+                .project(target: "DesignSystem", path: "../../DesignSystem"),
+                .project(target: "CoreNetwork", path: "../../Core/CoreNetwork")
             ]
         )
     ]

--- a/Soongan/Feature/ContestFeature/Sources/Logic/ContestDetailFeature.swift
+++ b/Soongan/Feature/ContestFeature/Sources/Logic/ContestDetailFeature.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 
+import CoreNetwork
 import DesignSystem
 import Shared
 
@@ -19,12 +20,15 @@ public struct ContestDetailFeature {
     
     @ObservableState
     public struct State: Equatable {
-        var contestTitle: String = "무제"
-        var contestAuthor: String = "@dkddkq222"
-        var isLiked: Bool = true
-        var likeCount: Int = 0
+        var postId: String
+        
+        var contestTitle: String?
+        var contestAuthor: String?
+        var isLiked: Bool?
+        var likeCount: Int?
         
         var isContestOptionSheetPresented: Bool = false
+        var isReportOptionSheetPresented: Bool = false
         
         var activeSheet: SheetContentType?
     }
@@ -38,13 +42,23 @@ public struct ContestDetailFeature {
     public enum Action: BindableAction {
         case binding(BindingAction<State>)
         
+        case onAppear
+        
         case likeButtonTapped
         case optionButtonTapped
+        case deleteButtonTapped
+        
+        case reportSheetIsPresented
         case optionSheetIsPresented(ContestReportReasonType)
         case dismissOptionSheet(Bool)
         case dismissSheet
         
         case backButtonTapped
+        
+        case onAppearSuccess(SearchDetailContestResponseDTO)
+        case likeButtonTappedSuccess(PostLikeResponseDTO)
+        
+        case contestDetailError(Error)
     }
     
     // MARK: - Body
@@ -52,6 +66,34 @@ public struct ContestDetailFeature {
     public var body: some ReducerOf<Self> {
         Reduce { state, action in
             switch action {
+            case .onAppear:
+                let postId = state.postId
+                
+                return .run { send in
+                    let result: Result<SearchDetailContestResponseDTO,NetworkError> = await NetworkManager.shared.request(WeeklyContestEndpoint.getDetailContest(postId: postId))
+                    
+                    switch result {
+                    case .success(let responseResult):
+                        await send(.onAppearSuccess(responseResult))
+                    case .failure(let error):
+                        await send(.contestDetailError(error))
+                    }
+                }
+                
+            case .onAppearSuccess(let response):
+                state.contestTitle = response.title
+                state.contestAuthor = response.nickname
+                state.isLiked = response.isLiked
+                state.likeCount = response.likeCount
+                
+                return .none
+                
+            case .reportSheetIsPresented:
+                state.isContestOptionSheetPresented = false
+                state.isReportOptionSheetPresented = true
+                
+                return .none
+                
             case .optionSheetIsPresented(let tappedOption):
                 state.isContestOptionSheetPresented = false
                 
@@ -78,7 +120,38 @@ public struct ContestDetailFeature {
                 return .none
                 
             case .likeButtonTapped:
+                let dto = PostLikeRequestDTO(postId: state.postId, contestType: "WEEKLY")
+                
+                let isLiked = state.isLiked ?? false
+                
+                return .run { send in
+                    let result: Result<PostLikeResponseDTO, NetworkError> = await NetworkManager.shared.request(isLiked ? PostLikeEndpoint.deletePostLike(dto) : PostLikeEndpoint.putPostLike(dto))
+                    
+                    switch result {
+                    case .success(let responseResult):
+                        await send(.likeButtonTappedSuccess(responseResult))
+                    case .failure(let error):
+                        await send(.contestDetailError(error))
+                    }
+                }
+            
+            case .likeButtonTappedSuccess(let response):
+                state.likeCount = Int(response.likeCount)
+                
                 return .none
+                
+            case .deleteButtonTapped:
+                let postId = state.postId
+                return .run { send in
+                    let result: Result<EmptyResponseDTO, NetworkError> = await NetworkManager.shared.request(WeeklyContestEndpoint.deleteContest(postId: postId))
+                    
+                    switch result {
+                    case .success:
+                        print("성공")
+                    case .failure(let error):
+                        print(error)
+                    }
+                }
                 
             case .dismissOptionSheet:
                 state.isContestOptionSheetPresented = false

--- a/Soongan/Feature/ContestFeature/Sources/Logic/ContestFeature.swift
+++ b/Soongan/Feature/ContestFeature/Sources/Logic/ContestFeature.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 
+import CoreNetwork
 import DesignSystem
 import Shared
 
@@ -55,6 +56,9 @@ public struct ContestFeature {
         
         case binding(BindingAction<State>)
     
+        case onAppear
+        case getContestSuccess(SearchWeeklyContestResponseDTO)
+        
         case presentSheet
         case chagneContestIndex
         case dismissContestSheet(Bool)
@@ -69,6 +73,31 @@ public struct ContestFeature {
         
         Reduce { state, action in
             switch action {
+            case .onAppear:
+                return .run { send in
+                    let dto = SearchWeeklyContestRequestDTO(
+                        round: 1,
+                        orderCriteria: "LATEST",
+                        page: 0,
+                        pageSize: 50
+                    )
+                    
+                    let result: Result<SearchWeeklyContestResponseDTO, NetworkError> = await NetworkManager.shared.request(WeeklyContestEndpoint.getContest(dto))
+                    
+                    switch result {
+                    case .success(let responseResult):
+                        await send(.getContestSuccess(responseResult))
+                    case .failure(let error):
+                        print(error.localizedDescription)
+                    }
+                }
+                
+            case .getContestSuccess(let response):
+                createImageData(response.posts)
+                
+                return .none
+                
+                
             case let .path(.element(id: _, action: action)):
                 switch action {
                 case .contestDetail(.backButtonTapped):
@@ -81,8 +110,8 @@ public struct ContestFeature {
             case .binding(_):
                 return .none
             
-            case .contestDetailImageTapped:
-                state.path.append(.contestDetail(ContestDetailFeature.State()))
+            case .contestDetailImageTapped(let postId):
+                state.path.append(.contestDetail(ContestDetailFeature.State(postId: postId)))
                 return .none
                 
             case .sortContestContentTapped:
@@ -118,5 +147,11 @@ public struct ContestFeature {
         
         let splitContest = contest.split(separator: " ").map{ String($0) }
         return (splitContest[0], splitContest[1])
+    }
+}
+
+private extension ContestFeature {
+    func createImageData(_ data: [PostInfoData]) {
+        
     }
 }

--- a/Soongan/Feature/ContestFeature/Sources/View/ContestDetailView.swift
+++ b/Soongan/Feature/ContestFeature/Sources/View/ContestDetailView.swift
@@ -39,10 +39,10 @@ struct ContestDetailView: View {
                 Spacer()
                 
                 VStack(alignment: .leading, spacing: 10) {
-                    Text(store.contestTitle)
+                    Text(store.contestTitle ?? "정보없음")
                         .font(.bold20)
                     
-                    Text(store.contestAuthor)
+                    Text("@" + (store.contestAuthor ?? "정보없음"))
                         .font(.medium14)
                         .padding(.leading, 4)
                 }
@@ -52,23 +52,40 @@ struct ContestDetailView: View {
             }
             .padding(.bottom, 83)
 
-            bottomOptionMenuBar()
+            bottomOptionMenuBar(isLiked: store.isLiked ?? false, likeCount: store.likeCount ?? 0)
+        }
+        .onAppear {
+            store.send(.onAppear)
         }
         .ignoresSafeArea(edges: .bottom)
         .background(DesignSystem.Color.soonganBG)
         .background(InteractivePopGestureEnabler())
+        .sheet(isPresented: $store.isContestOptionSheetPresented.sending(\.dismissOptionSheet)) {
+            CustomSheetView<DetailContestOptionType>(type: .detailContestOption) { type in
+                switch type {
+                case .edit:
+                    break
+                case .delete:
+                    store.send(.deleteButtonTapped)
+                case .report:
+                    store.send(.reportSheetIsPresented)
+                }
+            }
+        }
         .sheet(
-            isPresented: $store.isContestOptionSheetPresented.sending(\.dismissOptionSheet)
+            isPresented: $store.isReportOptionSheetPresented.sending(\.dismissOptionSheet)
         ) {
-            CustomSheetView(type: .contestReport) { _ in
-                
+            CustomSheetView<ContestReportReasonType>(type: .contestReport) { type in
+//                switch type {
+//                case .
+//                }
             }
         }
-        .sheet(item: $store.activeSheet) { sheetType in
-            CustomSheetView(type: sheetType) { optionType in
-                
-            }
-        }
+//        .sheet(item: $store.activeSheet) { sheetType in
+//            CustomSheetView(type: sheetType) { optionType in
+//                
+//            }
+//        }
         .toolbar(.hidden, for: .tabBar)
         .navigationBarBackButtonHidden(true)
         .toolbar {
@@ -86,7 +103,7 @@ struct ContestDetailView: View {
         }
     }
     
-    func bottomOptionMenuBar() -> some View {
+    func bottomOptionMenuBar(isLiked: Bool, likeCount: Int) -> some View {
         HStack(alignment: .top) {
             Button(action: {
                 store.send(.optionButtonTapped)
@@ -99,9 +116,9 @@ struct ContestDetailView: View {
             
             HStack(spacing: 0) {
                 Button(action: {
-                    
+                    store.send(.likeButtonTapped)
                 }) {
-                    if store.isLiked {
+                    if isLiked {
                         Image.selectLike
                     } else {
                         Image.notSelectLike
@@ -109,7 +126,7 @@ struct ContestDetailView: View {
                 }
                 .padding(.trailing, 8)
                 
-                Text("\(store.likeCount)")
+                Text("\(likeCount)")
                     .font(.info12)
                     .foregroundColor(DesignSystem.Color.black100)
                     .padding(.trailing, 32)
@@ -128,7 +145,7 @@ struct ContestDetailView: View {
     NavigationStack {
         ContestDetailView(
             store: Store(initialState:
-                            ContestDetailFeature.State()) {
+                            ContestDetailFeature.State(postId: String(10))) {
                                 ContestDetailFeature()
                             }
         )

--- a/Soongan/Feature/ContestFeature/Sources/View/ContestView.swift
+++ b/Soongan/Feature/ContestFeature/Sources/View/ContestView.swift
@@ -39,6 +39,9 @@ public struct ContestView: View {
             }
             .background(DesignSystem.Color.soonganBG)
             .toolbar(.hidden, for: .tabBar)
+            .onAppear {
+                store.send(.onAppear)
+            }
             .sheet(
                 isPresented: $store.isContestSheetPresented.sending(\.dismissContestSheet)
             ) {

--- a/Soongan/Feature/HomeFeature/Project.swift
+++ b/Soongan/Feature/HomeFeature/Project.swift
@@ -12,7 +12,7 @@ let project = Project(
         .target(
             name: "HomeFeature",
             destinations: .iOS,
-            product: .framework,
+            product: .staticFramework,
             bundleId: "com.captures.HomeFeature.Soongan",
             deploymentTargets: .iOS("17.0"),
             infoPlist: .default,
@@ -21,6 +21,7 @@ let project = Project(
             dependencies: [
                 .external(name: "ComposableArchitecture"),
                 .project(target: "DesignSystem", path: "../../DesignSystem"),
+                .project(target: "Shared", path: "../../Shared"),
                 .project(target: "CoreNetwork", path: "../../Core/CoreNetwork")
             ]
         )

--- a/Soongan/Feature/HomeFeature/Project.swift
+++ b/Soongan/Feature/HomeFeature/Project.swift
@@ -20,7 +20,8 @@ let project = Project(
             resources: [],
             dependencies: [
                 .external(name: "ComposableArchitecture"),
-                .project(target: "DesignSystem", path: "../../DesignSystem")
+                .project(target: "DesignSystem", path: "../../DesignSystem"),
+                .project(target: "CoreNetwork", path: "../../Core/CoreNetwork")
             ]
         )
     ]

--- a/Soongan/Feature/HomeFeature/Sources/Logic/HomeFeature.swift
+++ b/Soongan/Feature/HomeFeature/Sources/Logic/HomeFeature.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 
+import CoreNetwork
 import DesignSystem
 import Shared
 
@@ -61,6 +62,8 @@ public struct HomeFeature {
         case addPictureButtonTapped
         case infoButtonTapped
         case dismissInfoSheet(Bool)
+        
+        case homeInfoSuccess(SearchHomeInfoResponseDTO)
     }
     
     // MARK: - Body
@@ -69,7 +72,25 @@ public struct HomeFeature {
         Reduce { state, action in
             switch action {
             case .onAppear:
-                print("Home Appear")
+                return .run { send in
+                    let result: Result<SearchHomeInfoResponseDTO, NetworkError> = await NetworkManager.shared.request(HomeEndpoint.getHomeInfo)
+                    
+                    switch result {
+                    case .success(let responseResult):
+                        return await send(.homeInfoSuccess(responseResult))
+                    case .failure(let error):
+                        print(error.localizedDescription)
+                    }
+                }
+            
+            case .homeInfoSuccess(let result):
+                let contestData = result.contestInfo
+                let postData = result.postInfo
+            
+                state.startPeriod = contestData.startAt.toFormattedDateString()
+                state.endPeriod = contestData.endAt.toFormattedDateString()
+                state.weekTopic = contestData.subject
+            
                 return .none
                 
             case .addPictureButtonTapped:

--- a/Soongan/Feature/HomeFeature/Sources/Logic/PostPictureFeature.swift
+++ b/Soongan/Feature/HomeFeature/Sources/Logic/PostPictureFeature.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 import PhotosUI
 
+import CoreNetwork
 import DesignSystem
 import Shared
 

--- a/Soongan/Feature/HomeFeature/Sources/View/HomeView.swift
+++ b/Soongan/Feature/HomeFeature/Sources/View/HomeView.swift
@@ -75,7 +75,7 @@ public struct HomeView: View {
                                     .frame(width: 40, height: 40)
                                 
                                 Text("출품하기")
-                                    .font(.regualr14)
+                                    .font(.regular14)
                                     .foregroundStyle(Color.black100)
                             }
                         }
@@ -112,9 +112,7 @@ public struct HomeView: View {
             .sheet(
                 isPresented: $store.isInfoSheetPresented.sending(\.dismissInfoSheet)
             ) {
-                CustomSheetView(type: .contestInfo) {
-                    
-                }
+                CustomSheetView<NeverOption>(type: .contestInfo) { }
             }
         } destination: { store in
             switch store.case {

--- a/Soongan/Feature/HomeFeature/Sources/View/PostPictureView.swift
+++ b/Soongan/Feature/HomeFeature/Sources/View/PostPictureView.swift
@@ -67,7 +67,7 @@ public struct PostPictureView: View {
                         .foregroundColor(.black100)
                     
                     Text("\(store.textCount)/15")
-                        .font(.regualr8)
+                        .font(.regular8)
                         .foregroundColor(.black100)
                         .padding(.top, 8)
                         .padding(.trailing, 5)
@@ -82,7 +82,7 @@ public struct PostPictureView: View {
                 .padding(.horizontal, 136)
                 
                 Text("부적절한 사진은 삭제될 수 있습니다.")
-                    .font(.regualr12)
+                    .font(.regular12)
                     .foregroundColor(.black100)
                     .padding(.top, 12)
                     .padding(.bottom, 68)
@@ -98,9 +98,9 @@ public struct PostPictureView: View {
             .sheet(
                 isPresented: $store.isPostSheetPresented.sending(\.dismissPostSheet)
             ) {
-                CustomSheetView(type: .postPicture(name: store.postPictureName)) {
-                    
-                }
+//                CustomSheetView(type: .postPicture(name: store.postPictureName)) {
+//                    
+//                }
             }
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {
@@ -157,7 +157,7 @@ private extension PostPictureView {
                                     .frame(width: 40, height: 40)
                                 
                                 Text("출품하기")
-                                    .font(.regualr14)
+                                    .font(.regular14)
                                     .foregroundStyle(Color.black100)
                             }
                         }
@@ -181,6 +181,7 @@ private extension PostPictureView {
             Text("\(round)회차")
             
             Text("|")
+                .font(.medium20)
             
             Text(weekTopic)
         }

--- a/Soongan/Feature/MypageFeature/Project.swift
+++ b/Soongan/Feature/MypageFeature/Project.swift
@@ -12,7 +12,7 @@ let project = Project(
         .target(
             name: "MypageFeature",
             destinations: .iOS,
-            product: .framework,
+            product: .staticFramework,
             bundleId: "com.captures.MypageFeature.Soongan",
             deploymentTargets: .iOS("17.0"),
             infoPlist: .default,
@@ -21,6 +21,7 @@ let project = Project(
             dependencies: [
                 .external(name: "ComposableArchitecture"),
                 .project(target: "DesignSystem", path: "../../DesignSystem"),
+                .project(target: "Shared", path: "../../Shared"),
                 .project(target: "CoreNetwork", path: "../../Core/CoreNetwork")
             ]
         )

--- a/Soongan/Feature/MypageFeature/Project.swift
+++ b/Soongan/Feature/MypageFeature/Project.swift
@@ -20,7 +20,8 @@ let project = Project(
             resources: [],
             dependencies: [
                 .external(name: "ComposableArchitecture"),
-                .project(target: "DesignSystem", path: "../../DesignSystem")
+                .project(target: "DesignSystem", path: "../../DesignSystem"),
+                .project(target: "CoreNetwork", path: "../../Core/CoreNetwork")
             ]
         )
     ]

--- a/Soongan/Feature/MypageFeature/Sources/Logic/AlarmListFeature.swift
+++ b/Soongan/Feature/MypageFeature/Sources/Logic/AlarmListFeature.swift
@@ -7,13 +7,26 @@
 
 import SwiftUI
 
+import CoreNetwork
 import DesignSystem
 import Shared
 
 import ComposableArchitecture
 
-public enum AlarmTab {
-    case home, search, profile
+public enum AlarmTab: String {
+    case contest = "CONTEST"
+    case activity = "ACTIVITY"
+    case notice = "NOTICE"
+    
+    static func from(string: String) -> AlarmTab? {
+        return AlarmTab(rawValue: string)
+    }
+}
+
+public enum AlarmListError: Error {
+    case deleteAlarmError
+    case getNotificationError
+    case unreadNotificationError
 }
 
 @Reducer
@@ -22,7 +35,10 @@ public struct AlarmListFeature {
     @ObservableState
     public struct State: Equatable {
 
-        var selectedTab: AlarmTab = .home
+        var selectedTab: AlarmTab = .contest
+        
+        var unreadNotificationCount = [AlarmTab: Int]()
+        var alarmListModels = [AlarmTab: [AlarmListModel]]()
         
         public init() {}
     }
@@ -36,8 +52,19 @@ public struct AlarmListFeature {
     public enum Action: BindableAction {
         case binding(BindingAction<State>)
         
+        case onAppear
+        case getNotificationSuccess(String, [NotificationsInfoData])
+        case getUnreadNotificationSuccess([UnreadNotificationsResponseDTO])
+
         case topMenuButtonTapped(AlarmTab)
+        case alarmCellTapped(AlarmListModel)
+        case readNotificationSuccess(Int)
+        
+        case deleteAlarmButtonTapped(Int)
+        case deleteAlarmSuccess
         case backButtonTapped
+        
+        case alarmListFailure(AlarmListError)
     }
     
     // MARK: - Body
@@ -47,6 +74,81 @@ public struct AlarmListFeature {
         
         Reduce { state, action in
             switch action {
+                
+            case .onAppear:
+                return .run { send in
+                    let result: Result<[UnreadNotificationsResponseDTO], NetworkError> = await NetworkManager.shared.request(NotificationEndpoint.getUnreadNotificationCount)
+                    
+                    switch result {
+                    case .success(let responseResult):
+                        await send(.getUnreadNotificationSuccess(responseResult))
+                    case .failure:
+                        await send(.alarmListFailure(.unreadNotificationError))
+                    }
+                }
+                
+            case .getNotificationSuccess(let type, let response):
+                response.forEach {
+                    if let tab = AlarmTab.from(string: type) {
+                        state.alarmListModels[tab]?.append( AlarmListModel(
+                            id: $0.id,
+                            title: $0.title,
+                            content: $0.body,
+                            isRead: $0.isRead,
+                            redirectUrl: $0.redirectUrl,
+                            time: $0.createdAt
+                        ))
+                    }
+                }
+                
+                return .none
+                
+            case .getUnreadNotificationSuccess(let response):
+                response.forEach {
+                    if let tab = AlarmTab.from(string: $0.type) {
+                        state.unreadNotificationCount[tab] = $0.count
+                    }
+                }
+                
+                return .none
+                
+            case .alarmListFailure:
+                return .none
+                
+            case .alarmCellTapped(let data):
+                let dto = ReadNotificationsRequestDTO(notificationId: data.id)
+                
+                return .run { send in
+                    let result: Result<Int, NetworkError> = await NetworkManager.shared.request(NotificationEndpoint.postReadNotification(dto))
+                    
+                    switch result {
+                    case .success(let responseResult):
+                        await send(.readNotificationSuccess(responseResult))
+                    case .failure:
+                        await send(.alarmListFailure(.unreadNotificationError))
+                    }
+                }
+                
+            case .readNotificationSuccess(let response):
+                
+                return .none
+                
+            case .deleteAlarmButtonTapped(let id):
+                return .run { send in
+                    let result: Result<EmptyResponseDTO, NetworkError> = await NetworkManager.shared.request(NotificationEndpoint.deleteNotification(notificationId: id))
+                    
+                    switch result {
+                    case .success:
+                        await send(.deleteAlarmSuccess)
+                    case .failure:
+                        await send(.alarmListFailure(.deleteAlarmError))
+                    }
+                }
+                
+            case .deleteAlarmSuccess:
+                
+                return .none
+                
             case .binding(_):
                 return .none
                 
@@ -56,7 +158,18 @@ public struct AlarmListFeature {
             case .topMenuButtonTapped(let type):
                 state.selectedTab = type
                 
-                return .none
+                return .run { send in
+                    let dto = SearchNotificationsRequestDTO(type: type.rawValue)
+
+                    let result: Result<SearchNotificationsResponseDTO, NetworkError> = await NetworkManager.shared.request(NotificationEndpoint.getNotifications(dto))
+
+                    switch result {
+                    case .success(let responseResult):
+                        await send(.getNotificationSuccess(responseResult.type, responseResult.notifications))
+                    case .failure:
+                        await send(.alarmListFailure(.getNotificationError))
+                    }
+                }
             }
         }
     }

--- a/Soongan/Feature/MypageFeature/Sources/Logic/EditProfileFeature.swift
+++ b/Soongan/Feature/MypageFeature/Sources/Logic/EditProfileFeature.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 
+import CoreNetwork
 import DesignSystem
 import Shared
 
@@ -37,6 +38,8 @@ public struct EditProfileFeature {
     public enum Action: BindableAction {
         case binding(BindingAction<State>)
         
+        case editMyProfile
+        case editMyProfileSuccess(EditMyProfileResponseDTO)
         case backButtonTapped
     }
     
@@ -45,5 +48,38 @@ public struct EditProfileFeature {
     public var body: some ReducerOf<Self> {
         BindingReducer()
         
+        Reduce { state, action in
+            switch action {
+            case .editMyProfile:
+                let dto = EditMyProfileRequestDTO(
+                    nickname: state.nickname,
+                    selfIntroduction: state.introduce,
+                    profileImage: "",
+                    isDefaultProfileImage: false
+                )
+                
+                return .run { send in
+                    let result: Result<EditMyProfileResponseDTO, NetworkError> = await NetworkManager.shared.request(MemberEndpoint.patchProfile(dto))
+                    
+                    switch result {
+                    case .success(let responseResult):
+                        await send(.editMyProfileSuccess(responseResult))
+                    case .failure(let error):
+                        print(error)
+                    }
+                }
+                
+            case .editMyProfileSuccess(let response):
+
+                return .none
+            
+            case .backButtonTapped:
+                
+                return .none
+                
+            default:
+                return .none
+            }
+        }
     }
 }

--- a/Soongan/Feature/MypageFeature/Sources/Logic/MypageFeature.swift
+++ b/Soongan/Feature/MypageFeature/Sources/Logic/MypageFeature.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 
+import CoreNetwork
 import DesignSystem
 import Shared
 
@@ -35,6 +36,10 @@ public struct MypageFeature {
         var shouldNavigateToEditProfile: Bool = false
         var shouldNavigateToQuestionsList: Bool = false
         
+        var userName = ""
+        var userIntroduce = ""
+        
+        
         var activeSheet: SheetContentType?
         
         // CustomTabBar 가시성
@@ -55,12 +60,17 @@ public struct MypageFeature {
         case path(StackActionOf<MypagePath>)
         
         case binding(BindingAction<State>)
+        
+        case onAppear
         case alarmButtonTapped
         case optionButtonTapped
         case optionSheetIsPresented(MyprofileOptionType)
         case presentSheet(SheetContentType)
         case dismissOptionSheet(Bool)
         case dismissSheet
+        
+        case myInfoSuccess(SearchMyProfileResponseDTO)
+        case myContestInfoSuccess(SearchMyContestResponseDTO)
     }
     
     // MARK: - Body
@@ -70,6 +80,46 @@ public struct MypageFeature {
         
         Reduce { state, action in
             switch action {
+            case .onAppear:
+                let dto = SearchMyContestRequestDTO(page: 0, pageSize: 50)
+                
+                return .run { send in
+                    async let myInfoResult: Result<SearchMyProfileResponseDTO, NetworkError> = NetworkManager.shared.request(MemberEndpoint.getMembers)
+                    
+                    async let myContestInfoResult: Result<SearchMyContestResponseDTO, NetworkError> = NetworkManager.shared.request(WeeklyContestEndpoint.getMyContest(dto))
+                    
+                    // await 둘 다 병렬로 완료
+                    let (infoResult, contestResult) = await (myInfoResult, myContestInfoResult)
+                    
+                    // 개별 처리
+                    switch infoResult {
+                    case .success(let info):
+                        await send(.myInfoSuccess(info))
+                    case .failure(let error):
+                        print("Profile Error: \(error.localizedDescription)")
+//                        await send(.myInfoFailure(error))
+                    }
+
+                    switch contestResult {
+                    case .success(let contest):
+                        await send(.myContestInfoSuccess(contest))
+                    case .failure(let error):
+                        print("Contest Error: \(error.localizedDescription)")
+//                        await send(.myContestFailure(error))
+                    }
+                }
+                
+            case .myInfoSuccess(let response):
+                state.userName = response.nickname ?? "정보없음"
+                state.userIntroduce = response.selfIntroduction ?? "정보없음"
+                
+                return .none
+                
+            case .myContestInfoSuccess(let response):
+                
+                // TODO: - 나의 콘테스트 게시글 보여주기
+                return .none
+                
             case let .path(.element(id: _, action: action)):
                 switch action {
                 case .editProfile(.backButtonTapped), .alarmList(.backButtonTapped), .questionsList(.backButtonTapped):

--- a/Soongan/Feature/MypageFeature/Sources/Model/AlarmListModel.swift
+++ b/Soongan/Feature/MypageFeature/Sources/Model/AlarmListModel.swift
@@ -7,15 +7,11 @@
 
 import Foundation
 
-struct AlarmListModel: Identifiable, Hashable {
-    let id = UUID()
-    let title: String
-    let content: String
-    let time: String
-    
-    init(title: String, content: String, time: String) {
-        self.title = title
-        self.content = content
-        self.time = time
-    }
+public struct AlarmListModel: Identifiable, Hashable {
+    public let id: Int
+    public let title: String
+    public let content: String
+    public let isRead: Bool
+    public let redirectUrl: String
+    public let time: String
 }

--- a/Soongan/Feature/MypageFeature/Sources/View/AlarmListView.swift
+++ b/Soongan/Feature/MypageFeature/Sources/View/AlarmListView.swift
@@ -16,13 +16,6 @@ public struct AlarmListView: View {
     
     @Bindable var store: StoreOf<AlarmListFeature>
     
-    private var alarmListModels = [
-        AlarmListModel(title: "<위클리 콘> 새로운 주제가 발표됐어요~", content: "이번 콘테스트의 주제는 무엇일까요?\n지금 바로 확인해보세요!", time: "2일 전"),
-        AlarmListModel(title: "<위클리 콘> 새로운 주제가 발표됐어요~", content: "이번 콘테스트의 주제는 무엇일까요?\n지금 바로 확인해보세요!", time: "3일 전"),
-        AlarmListModel(title: "<위클리 콘> 새로운 주제가 발표됐어요~", content: "이번 콘테스트의 주제는 무엇일까요?\n지금 바로 확인해보세요!\n콘테스트의 주제는 무엇일까요?\n지금 바로 확인해보세요!", time: "5일전"),
-        AlarmListModel(title: "<위클리 콘> 새로운 주제가 발표됐어요~", content: "이번 콘테스트의 주제는 무엇일까요?\n지금 바로 확인해보세요!", time: "10일전")
-    ]
-    
     // MARK: - Init
     
     public init(
@@ -37,21 +30,21 @@ public struct AlarmListView: View {
         VStack(spacing: 0) {
             HStack(spacing: 18) {
                 TopTabButtonView(
-                    title: "대회 알림",
-                    isSelected: store.selectedTab == .home,
-                    action: { store.send(.topMenuButtonTapped(.home)) }
+                    title: "대회 알림" + (store.unreadNotificationCount[.contest].flatMap { $0 > 0 ? " \($0)" : nil } ?? ""),
+                    isSelected: store.selectedTab == .contest,
+                    action: { store.send(.topMenuButtonTapped(.contest)) }
                 )
                 
                 TopTabButtonView(
-                    title: "활동 알림",
-                    isSelected: store.selectedTab == .search,
-                    action: { store.send(.topMenuButtonTapped(.search)) }
+                    title: "활동 알림" + (store.unreadNotificationCount[.activity].flatMap { $0 > 0 ? " \($0)" : nil } ?? ""),
+                    isSelected: store.selectedTab == .activity,
+                    action: { store.send(.topMenuButtonTapped(.activity)) }
                 )
 
                 TopTabButtonView(
-                    title: "공지 알림",
-                    isSelected: store.selectedTab == .profile,
-                    action: { store.send(.topMenuButtonTapped(.profile)) }
+                    title: "공지 알림" + (store.unreadNotificationCount[.notice].flatMap { $0 > 0 ? " \($0)" : nil } ?? ""),
+                    isSelected: store.selectedTab == .notice,
+                    action: { store.send(.topMenuButtonTapped(.notice)) }
                 )
             }
             .padding(.top, 26)
@@ -61,45 +54,14 @@ public struct AlarmListView: View {
                 .background(DesignSystem.Color.black80)
                 .frame(height: 2)
             
-            // 선택된 화면 보여주기
             Group {
-                switch store.selectedTab {
-                case .home:
-                    List {
-                        ForEach(alarmListModels) { alarmData in
-                            VStack(alignment: .leading, spacing: 0) {
-                                alarmListContent(data: alarmData)
-                                    .padding(.vertical, 20)
-                                    .padding(.horizontal, 12)
-                                
-                                Divider()
-                                    .frame(height: 0.7)
-                                    .background(DesignSystem.Color.black40)
-                            }
-                            .listRowSeparator(.hidden)
-                            .listRowInsets(EdgeInsets(top: 0, leading: 20, bottom: 0, trailing: 20))
-                            .swipeActions {
-                                Button(role: .destructive) {
-                                    // delete(item: item)
-                                } label: {
-                                    Image.deleteList
-                                }
-                            }
-                        }
-                        .listRowBackground(Color.clear)
-                        .scrollContentBackground(.hidden)
-                        .background(Color.clear)
-                    }
-                    .listStyle(.plain)
-                    
-                case .search:
-                    Text("asdfasdfasdfasdf")
-                    
-                case .profile:
-                    Text("asdfasdf")
-                }
+                alarmList(store.selectedTab)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .onAppear {
+            store.send(.onAppear)
+            store.send(.topMenuButtonTapped(.contest))
         }
         .background(DesignSystem.Color.soonganBG)
         .background(InteractivePopGestureEnabler())
@@ -126,10 +88,43 @@ public struct AlarmListView: View {
         }
     }
     
-    func delete(item: AlarmListModel) {
-//        if let index = items.firstIndex(where: { $0.id == item.id }) {
-//            items.remove(at: index)
-//        }
+    @ViewBuilder
+    func alarmList(_ tab: AlarmTab) -> some View {
+        if let alarmList = store.alarmListModels[store.selectedTab] {
+            List {
+                ForEach(alarmList) { alarmData in
+                    VStack(alignment: .leading, spacing: 0) {
+                        alarmListContent(data: alarmData)
+                            .padding(.leading, alarmData.isRead ? 20 : 12)
+                            .padding(.trailing, 20)
+                            .padding(.horizontal, 12)
+                        
+                        Divider()
+                            .frame(height: 0.7)
+                            .background(DesignSystem.Color.black40)
+                    }
+                    .listRowSeparator(.hidden)
+                    .listRowInsets(EdgeInsets(top: 0, leading: 20, bottom: 0, trailing: 20))
+                    .onTapGesture {
+                        store.send(.alarmCellTapped(alarmData)) // Action 추가
+                    }
+                    .swipeActions {
+                        Button(role: .destructive) {
+                            store.send(.deleteAlarmButtonTapped(alarmData.id))
+                        } label: {
+                            Image.deleteList
+                        }
+                    }
+                }
+                .listRowBackground(Color.clear)
+                .scrollContentBackground(.hidden)
+                .background(Color.clear)
+            }
+            .listStyle(.plain)
+        } else {
+            Text("알람이 없습니다.")
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
     }
 }
 
@@ -137,18 +132,27 @@ public struct AlarmListView: View {
 
 private extension AlarmListView {
     private func alarmListContent(data: AlarmListModel) -> some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text(data.title)
-                .font(.bold16)
-                .foregroundColor(DesignSystem.Color.black100)
+        HStack(spacing: 12) {
+            if !data.isRead {
+                Image(systemName: "circle.fill")
+                    .resizable()
+                    .frame(width: 8, height: 8)
+                    .foregroundColor(DesignSystem.Color.primary)
+            }
             
-            Text(data.content)
-                .font(.bold12)
-                .foregroundColor(DesignSystem.Color.black100)
-            
-            Text(data.time)
-                .font(.regualr12)
-                .foregroundColor(DesignSystem.Color.black100)
+            VStack(alignment: .leading, spacing: 8) {
+                Text(data.title)
+                    .font(.bold16)
+                    .foregroundColor(DesignSystem.Color.black100)
+                
+                Text(data.content)
+                    .font(.bold12)
+                    .foregroundColor(DesignSystem.Color.black100)
+                
+                Text(data.time)
+                    .font(.regular12)
+                    .foregroundColor(DesignSystem.Color.black100)
+            }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
     }

--- a/Soongan/Feature/MypageFeature/Sources/View/EditProfileView.swift
+++ b/Soongan/Feature/MypageFeature/Sources/View/EditProfileView.swift
@@ -71,7 +71,7 @@ public struct EditProfileView: View {
                 Spacer()
                 
                 CustomBottomButton(type: .editComplete, isEnable: $store.editButtonState) {
-                    
+                    store.send(.editMyProfile)
                 }
                 .padding(.horizontal, 136)
                 .padding(.bottom, 93)

--- a/Soongan/Feature/MypageFeature/Sources/View/MypageView.swift
+++ b/Soongan/Feature/MypageFeature/Sources/View/MypageView.swift
@@ -58,11 +58,14 @@ public struct MypageView: View {
                 }
             }
             .sheet(item: $store.activeSheet) { sheetType in
-                CustomSheetView(type: sheetType) { optionType in
+                CustomSheetView<MyprofileOptionType>(type: sheetType) { optionType in
 //                    if let optionType = optionType as? MyprofileOptionType {
 //                        store.send(.optionSelected(optionType))
 //                    }
                 }
+            }
+            .onAppear {
+                store.send(.onAppear)
             }
         } destination: { store in
             switch store.case {
@@ -82,11 +85,11 @@ public struct MypageView: View {
 private extension MypageView {
     func profileHeaderSection() -> some View {
         VStack(alignment: .leading, spacing: 10) {
-            Text("user1")
+            Text(store.userName)
                 .font(.medium16)
             
-            Text("본인을 소개해주세요")
-                .font(.regualr12)
+            Text(store.userIntroduce)
+                .font(.regular12)
         }
         .foregroundStyle(Color.black100)
     }

--- a/Soongan/Project.swift
+++ b/Soongan/Project.swift
@@ -20,6 +20,14 @@ let project = Project(
                         "UIColorName": "",
                         "UIImageName": "",
                     ],
+                    "BASE_URL": "$(BASE_URL)",
+                    "ACCESS_TOKEN_KEY": "$(ACCESS_TOKEN_KEY)",
+                    "REFRESH_TOKEN_KEY": "$(REFRESH_TOKEN_KEY)",
+                    "KAKAO_NATIVE_APP_KEY": "$(KAKAO_NATIVE_APP_KEY)",
+                    "LSApplicationQueriesSchemes": [
+                      "kakaokompassauth",
+                      "kakaolink"
+                    ],
                 ]
             ),
             sources: ["Soongan/Sources/**"],
@@ -29,6 +37,7 @@ let project = Project(
                 .external(name: "KakaoSDKAuth"),
                 .external(name: "KakaoSDKUser"),
                 .external(name: "ComposableArchitecture"),
+                .external(name: "FirebaseMessaging"),
                 .project(target: "Resource", path: "Resource"),
                 .project(target: "Shared", path: "Shared"),
                 .project(target: "DesignSystem", path: "DesignSystem"),
@@ -36,7 +45,8 @@ let project = Project(
                 .project(target: "HomeFeature", path: "Feature/HomeFeature"),
                 .project(target: "ContestFeature", path: "Feature/ContestFeature"),
                 .project(target: "AllTimeContestFeature", path: "Feature/AllTimeContestFeature"),
-                .project(target: "MypageFeature", path: "Feature/MypageFeature")
+                .project(target: "MypageFeature", path: "Feature/MypageFeature"),
+                .project(target: "CoreNetwork", path: "Core/CoreNetwork")
             ]
         ),
         .target(

--- a/Soongan/Project.swift
+++ b/Soongan/Project.swift
@@ -5,7 +5,10 @@ let project = Project(
     organizationName: "Captures",
     settings: .settings(
         base: [
-            "DEVELOPMENT_TEAM": "9KHXTZ4SZ9"
+            "DEVELOPMENT_TEAM": "N3H27N59VG",
+        ],
+        configurations: [
+            .debug(name: "Debug", xcconfig: .relativeToRoot("Soongan/Configs/Debug.xcconfig")),
         ]
     ),
     targets: [
@@ -21,17 +24,30 @@ let project = Project(
                         "UIImageName": "",
                     ],
                     "BASE_URL": "$(BASE_URL)",
+                    "PROJECT_KEY": "$(PROJECT_KEY)",
                     "ACCESS_TOKEN_KEY": "$(ACCESS_TOKEN_KEY)",
                     "REFRESH_TOKEN_KEY": "$(REFRESH_TOKEN_KEY)",
                     "KAKAO_NATIVE_APP_KEY": "$(KAKAO_NATIVE_APP_KEY)",
+                    "CFBundleURLTypes": [
+                        [
+                            "CFBundleURLSchemes": [ "kakao$(KAKAO_NATIVE_APP_KEY)" ]
+                        ]
+                    ],
                     "LSApplicationQueriesSchemes": [
                       "kakaokompassauth",
                       "kakaolink"
                     ],
+                    "UIBackgroundModes": [
+                        "remote-notification"
+                    ],
                 ]
             ),
             sources: ["Soongan/Sources/**"],
-            resources: ["Soongan/Resources/**"],
+            resources: [
+                "Soongan/Resources/**",
+                "Soongan/GoogleService-Info.plist"
+            ],
+            entitlements: .file(path: "Soongan/Soongan.entitlements"),
             dependencies: [
                 .external(name: "KakaoSDKCommon"),
                 .external(name: "KakaoSDKAuth"),

--- a/Soongan/Resource/Resources/Assets/Image.xcassets/CheckIcon.imageset/CheckIcon.svg
+++ b/Soongan/Resource/Resources/Assets/Image.xcassets/CheckIcon.imageset/CheckIcon.svg
@@ -1,0 +1,3 @@
+<svg width="14" height="15" viewBox="0 0 14 15" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M13 1L5.32001 13L1 6.38288" stroke="white" stroke-width="2" stroke-miterlimit="10"/>
+</svg>

--- a/Soongan/Resource/Resources/Assets/Image.xcassets/CheckIcon.imageset/Contents.json
+++ b/Soongan/Resource/Resources/Assets/Image.xcassets/CheckIcon.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "filename" : "CheckIcon.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Soongan/Shared/Sources/Extension/String+.swift
+++ b/Soongan/Shared/Sources/Extension/String+.swift
@@ -45,4 +45,20 @@ public extension String {
 
         return .valid
     }
+    
+    func toFormattedDateString() -> String {
+        let isoFormatter = DateFormatter()
+        isoFormatter.locale = Locale(identifier: "en_US_POSIX")
+        isoFormatter.timeZone = TimeZone(secondsFromGMT: 0)
+        isoFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
+        
+        let outputFormatter = DateFormatter()
+        outputFormatter.locale = Locale(identifier: "ko_KR")
+        outputFormatter.dateFormat = "yyyy.MM.dd HH:mm:ss"
+        
+        guard let date = isoFormatter.date(from: self) else {
+            return "알수없음"
+        }
+        return outputFormatter.string(from: date)
+    }
 }

--- a/Soongan/Soongan/Soongan.entitlements
+++ b/Soongan/Soongan/Soongan.entitlements
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>aps-environment</key>
+	<string>development</string>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+</dict>
+</plist>

--- a/Soongan/Soongan/Soongan.entitlements.swift
+++ b/Soongan/Soongan/Soongan.entitlements.swift
@@ -2,9 +2,9 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.developer.applesignin</key>
-	<array>
-		<string>Default</string>
-	</array>
+    <key>aps-environment</key>
+    <string>development</string>
+    <key>com.apple.developer.usernotifications.filtering</key>
+    <true/>
 </dict>
 </plist>

--- a/Soongan/Soongan/Sources/AppFeature.swift
+++ b/Soongan/Soongan/Sources/AppFeature.swift
@@ -18,7 +18,7 @@ public struct AppFeature {
     
     @ObservableState
     public struct State: Equatable {
-        @Shared(.appStorage("AuthState")) var authState: AuthType = .loggedIn
+        @Shared(.appStorage("AuthState")) var authState: AuthType = .loggedOut
         var login: LoginFeature.State = LoginFeature.State()
         var mainTab: MainTabFeature.State = MainTabFeature.State()
     }
@@ -40,6 +40,8 @@ public struct AppFeature {
         Reduce { state, action in
             switch action {
             case .login(.delegate(.loginSuccess)):
+                
+                print("AppFeature 로 데이터 옴")
                 state.$authState.withLock { $0 = .loggedIn }
                 
                 return .none

--- a/Soongan/Soongan/Sources/Config.swift
+++ b/Soongan/Soongan/Sources/Config.swift
@@ -1,0 +1,33 @@
+//
+//  Config.swift
+//  Soongan
+//
+//  Created by ParkJunHyuk on 6/17/25.
+//  Copyright © 2025 Captures. All rights reserved.
+//
+
+import Foundation
+
+enum Config {
+    enum Keys {
+        enum Plist {
+            static let kakaoNativeAppKey = "KAKAO_NATIVE_APP_KEY"
+        }
+    }
+    
+    private static let infoDictionary: [String: Any] = {
+        guard let dict = Bundle.main.infoDictionary else {
+            fatalError("plist cannot found !!!")
+        }
+        return dict
+    }()
+}
+
+extension Config {
+    public static let kakaoNativeAppKey: String = {
+        guard let key = Config.infoDictionary[Keys.Plist.kakaoNativeAppKey] as? String else {
+            fatalError("⛔️KAKAO_NATIVE_APP_KEY is not set in plist for this configuration⛔️")
+        }
+        return key
+    }()
+}

--- a/Soongan/Soongan/Sources/SoonganApp.swift
+++ b/Soongan/Soongan/Sources/SoonganApp.swift
@@ -11,7 +11,9 @@ import UserNotifications
 
 import AuthFeature
 import CoreKeyChain
+import CoreNetwork
 
+import Alamofire
 import ComposableArchitecture
 import Firebase
 import FirebaseMessaging
@@ -37,6 +39,11 @@ struct SoonganApp: App {
                     }
                 )
             )
+            .onOpenURL { url in
+                if (AuthApi.isKakaoTalkLoginUrl(url)) {
+                    _ = AuthController.handleOpenUrl(url: url)
+                }
+            }
         }
     }
 }
@@ -60,6 +67,16 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         
         return true
     }
+    
+//    func application(_ app: UIApplication, open url: URL,
+//                     options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
+//        
+//        if (AuthApi.isKakaoTalkLoginUrl(url)) {
+//            return AuthController.handleOpenUrl(url: url)
+//        }
+//        
+//        return false
+//    }
     
     // MARK: - 원격 알림 권한 요청
     
@@ -113,14 +130,56 @@ extension AppDelegate: MessagingDelegate {
         )
         
         // 서버에 토큰 전송 (필요시)
-        sendTokenToServer(fcmToken)
+        Task {
+            await sendTokenToServer(fcmToken)
+        }
     }
     
-    private func sendTokenToServer(_ token: String?) {
+    private func sendTokenToServer(_ token: String?) async {
         guard let token = token else { return }
         
+        let deviceId = UIDevice.current.identifierForVendor?.uuidString ?? ""
         // TODO: 서버에 FCM 토큰 전송하는 로직 구현
-        print("서버에 토큰 전송: \(token)")
+        print("🚀 FCM Token 등록 API 호출 ==========================")
+        print(deviceId)
+        let dto = RegisterFCMTokenRequestDTO(token: token, deviceId: deviceId)
+        
+        let endpoint = FCMEndpoint.postFcmToken(dto)
+//        let url = endpoint.baseURL.appendingPathComponent(endpoint.path)
+//        let parameters = try? endpoint.parameters.flatMap { encodable -> [String: Any]? in
+//            let data = try JSONEncoder().encode(encodable)
+//            return try JSONSerialization.jsonObject(with: data) as? [String: Any]
+//        }
+//        
+//        let dataTask = AF.request(
+//            url,
+//            method: endpoint.method,
+//            parameters: parameters,
+//            encoding: JSONEncoding.default,
+//            headers: endpoint.headers
+//        )
+        
+        let session = Session(eventMonitors: [NetworkLogger()])
+        
+        let dataTask = session.request(APIRouter(endpoint: endpoint))
+        .validate(statusCode: 200..<300)
+        .serializingDecodable(APIResponse<RegisterFCMTokenResponseDTO>.self)
+        
+        let response = await dataTask.response
+        
+//        print("➡️ URL: \(url)")
+//        print("➡️ Header: \(String(describing: endpoint.headers))")
+//        print("➡️ StatusCode: \(String(describing: response.response?.statusCode))")
+//        print("➡️ parameters: \(String(describing: parameters))")
+        
+        switch response.result {
+        case .success(let apiResponse):
+            print("✅ FCM Token 등록 API 성공 ==========================")
+//            print(apiResponse)
+        case .failure(let error):
+            print("⚠️ FCM Token 등록 API 에러 발생 ==========================")
+            print("\(error)")
+        }
     }
 }
 

--- a/Soongan/Soongan/Sources/SoonganApp.swift
+++ b/Soongan/Soongan/Sources/SoonganApp.swift
@@ -7,12 +7,26 @@
 //
 
 import SwiftUI
-import ComposableArchitecture
+import UserNotifications
 
 import AuthFeature
+import CoreKeyChain
+
+import ComposableArchitecture
+import Firebase
+import FirebaseMessaging
+import KakaoSDKAuth
+import KakaoSDKCommon
 
 @main
 struct SoonganApp: App {
+    
+    @UIApplicationDelegateAdaptor(AppDelegate.self) var delegate
+    
+    init() {
+        KakaoSDK.initSDK(appKey: Config.kakaoNativeAppKey)
+    }
+    
     var body: some Scene {
         WindowGroup {
             AppView(
@@ -23,6 +37,130 @@ struct SoonganApp: App {
                     }
                 )
             )
+        }
+    }
+}
+
+class AppDelegate: NSObject, UIApplicationDelegate {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
+        
+        // MARK: - FireBase 설정
+        
+        // Firebase 초기화
+        FirebaseApp.configure()
+        
+        // FCM Delegate 설정
+        Messaging.messaging().delegate = self
+        
+        // UNUserNotificationCenter delegate 설정
+        UNUserNotificationCenter.current().delegate = self
+        
+        // 원격 알림 권한 요청
+        requestNotificationPermission()
+        
+        return true
+    }
+    
+    // MARK: - 원격 알림 권한 요청
+    
+    private func requestNotificationPermission() {
+        let authOptions: UNAuthorizationOptions = [.alert, .badge, .sound]
+        UNUserNotificationCenter.current().requestAuthorization(options: authOptions) { granted, error in
+            if let error = error {
+                print("알림 권한 요청 실패: \(error.localizedDescription)")
+                return
+            }
+            
+            print("알림 권한 승인: \(granted)")
+            
+            DispatchQueue.main.async {
+                UIApplication.shared.registerForRemoteNotifications()
+            }
+        }
+    }
+    
+    // MARK: - APNs 토큰 등록 성공
+    
+    func application(_ application: UIApplication,
+                   didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+        Messaging.messaging().apnsToken = deviceToken
+        print("APNs 토큰 등록 성공")
+    }
+    
+    // MARK: - APNs 토큰 등록 실패
+    
+    func application(_ application: UIApplication,
+                   didFailToRegisterForRemoteNotificationsWithError error: Error) {
+        print("APNs 토큰 등록 실패: \(error.localizedDescription)")
+    }
+}
+
+extension AppDelegate: MessagingDelegate {
+    // FCM 토큰이 갱신될 때마다 호출
+    func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {
+        print("📱 FCM 토큰 수신: \(fcmToken ?? "nil")")
+        
+        if let fcmToken {
+            let _ = KeychainManager.shared.save(key: .fcmToken, value: fcmToken)
+        }
+        
+        // 토큰이 변경되었음을 알리는 노티피케이션 발송
+        let dataDict: [String: String] = ["token": fcmToken ?? ""]
+        NotificationCenter.default.post(
+            name: Notification.Name("FCMToken"),
+            object: nil,
+            userInfo: dataDict
+        )
+        
+        // 서버에 토큰 전송 (필요시)
+        sendTokenToServer(fcmToken)
+    }
+    
+    private func sendTokenToServer(_ token: String?) {
+        guard let token = token else { return }
+        
+        // TODO: 서버에 FCM 토큰 전송하는 로직 구현
+        print("서버에 토큰 전송: \(token)")
+    }
+}
+
+
+extension AppDelegate: UNUserNotificationCenterDelegate {
+    // Foreground 상태에서 알림 받았을 때 - 알림 표시만 설정
+    func userNotificationCenter(_ center: UNUserNotificationCenter,
+                                willPresent notification: UNNotification,
+                                withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
+        
+        let userInfo = notification.request.content.userInfo
+        print("포그라운드 알림 수신: \(userInfo)")
+        
+        completionHandler([[.banner, .badge, .sound]])
+    }
+    
+    // 알림 탭했을 때의 실제 동작 처리
+    func userNotificationCenter(_ center: UNUserNotificationCenter,
+                                didReceive response: UNNotificationResponse,
+                                withCompletionHandler completionHandler: @escaping () -> Void) {
+        
+        print("SceneDelegate 푸시 메세지를 받았습니다.")
+        
+        let userInfo = response.notification.request.content.userInfo
+        print("알림 탭:", userInfo)
+//        decodeUserInfo(userInfo)
+        
+        // TODO: 알림 탭 시 특정 화면으로 이동하는 로직 구현
+        
+        completionHandler()
+    }
+    
+    func decodeUserInfo(_ userInfo: [AnyHashable: Any]) {
+        do {
+            let data = try JSONSerialization.data(withJSONObject: userInfo, options: [])
+            if let jsonString = String(data: data, encoding: .utf8) {
+                print("Decoded JSON: \(jsonString)")
+            }
+        } catch {
+            print("Error decoding userInfo: \(error)")
         }
     }
 }

--- a/Soongan/Tuist/Package.resolved
+++ b/Soongan/Tuist/Package.resolved
@@ -1,0 +1,267 @@
+{
+  "originHash" : "50385db05bf9b03bc5475148e01fde0d3e58275a3094ae2289ebe690eeef33b7",
+  "pins" : [
+    {
+      "identity" : "abseil-cpp-binary",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/abseil-cpp-binary.git",
+      "state" : {
+        "revision" : "194a6706acbd25e4ef639bcaddea16e8758a3e27",
+        "version" : "1.2024011602.0"
+      }
+    },
+    {
+      "identity" : "alamofire",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Alamofire/Alamofire.git",
+      "state" : {
+        "revision" : "513364f870f6bfc468f9d2ff0a95caccc10044c5",
+        "version" : "5.10.2"
+      }
+    },
+    {
+      "identity" : "app-check",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/app-check.git",
+      "state" : {
+        "revision" : "3b62f154d00019ae29a71e9738800bb6f18b236d",
+        "version" : "10.19.2"
+      }
+    },
+    {
+      "identity" : "combine-schedulers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/combine-schedulers",
+      "state" : {
+        "revision" : "5928286acce13def418ec36d05a001a9641086f2",
+        "version" : "1.0.3"
+      }
+    },
+    {
+      "identity" : "firebase-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/firebase-ios-sdk.git",
+      "state" : {
+        "revision" : "eca84fd638116dd6adb633b5a3f31cc7befcbb7d",
+        "version" : "10.29.0"
+      }
+    },
+    {
+      "identity" : "googleappmeasurement",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleAppMeasurement.git",
+      "state" : {
+        "revision" : "fe727587518729046fc1465625b9afd80b5ab361",
+        "version" : "10.28.0"
+      }
+    },
+    {
+      "identity" : "googledatatransport",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleDataTransport.git",
+      "state" : {
+        "revision" : "a637d318ae7ae246b02d7305121275bc75ed5565",
+        "version" : "9.4.0"
+      }
+    },
+    {
+      "identity" : "googleutilities",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleUtilities.git",
+      "state" : {
+        "revision" : "57a1d307f42df690fdef2637f3e5b776da02aad6",
+        "version" : "7.13.3"
+      }
+    },
+    {
+      "identity" : "grpc-binary",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/grpc-binary.git",
+      "state" : {
+        "revision" : "e9fad491d0673bdda7063a0341fb6b47a30c5359",
+        "version" : "1.62.2"
+      }
+    },
+    {
+      "identity" : "gtm-session-fetcher",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/gtm-session-fetcher.git",
+      "state" : {
+        "revision" : "a2ab612cb980066ee56d90d60d8462992c07f24b",
+        "version" : "3.5.0"
+      }
+    },
+    {
+      "identity" : "interop-ios-for-google-sdks",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/interop-ios-for-google-sdks.git",
+      "state" : {
+        "revision" : "2d12673670417654f08f5f90fdd62926dc3a2648",
+        "version" : "100.0.0"
+      }
+    },
+    {
+      "identity" : "kakao-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kakao/kakao-ios-sdk",
+      "state" : {
+        "revision" : "2c780b70d4197be3f72deee2fd82ea3e3b767007",
+        "version" : "2.24.1"
+      }
+    },
+    {
+      "identity" : "leveldb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/leveldb.git",
+      "state" : {
+        "revision" : "a0bc79961d7be727d258d33d5a6b2f1023270ba1",
+        "version" : "1.22.5"
+      }
+    },
+    {
+      "identity" : "nanopb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/nanopb.git",
+      "state" : {
+        "revision" : "b7e1104502eca3a213b46303391ca4d3bc8ddec1",
+        "version" : "2.30910.0"
+      }
+    },
+    {
+      "identity" : "promises",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/promises.git",
+      "state" : {
+        "revision" : "540318ecedd63d883069ae7f1ed811a2df00b6ac",
+        "version" : "2.4.0"
+      }
+    },
+    {
+      "identity" : "swift-case-paths",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-case-paths",
+      "state" : {
+        "revision" : "41b89b8b68d8c56c622dbb7132258f1a3e638b25",
+        "version" : "1.7.0"
+      }
+    },
+    {
+      "identity" : "swift-clocks",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-clocks",
+      "state" : {
+        "revision" : "cc46202b53476d64e824e0b6612da09d84ffde8e",
+        "version" : "1.0.6"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections",
+      "state" : {
+        "revision" : "671108c96644956dddcd89dd59c203dcdb36cec7",
+        "version" : "1.1.4"
+      }
+    },
+    {
+      "identity" : "swift-composable-architecture",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-composable-architecture.git",
+      "state" : {
+        "revision" : "b1d27a82b498b8e697acabd8cc01b585d26aab19",
+        "version" : "1.19.1"
+      }
+    },
+    {
+      "identity" : "swift-concurrency-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-concurrency-extras",
+      "state" : {
+        "revision" : "82a4ae7170d98d8538ec77238b7eb8e7199ef2e8",
+        "version" : "1.3.1"
+      }
+    },
+    {
+      "identity" : "swift-custom-dump",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-custom-dump",
+      "state" : {
+        "revision" : "82645ec760917961cfa08c9c0c7104a57a0fa4b1",
+        "version" : "1.3.3"
+      }
+    },
+    {
+      "identity" : "swift-dependencies",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-dependencies",
+      "state" : {
+        "revision" : "4c90d6b2b9bf0911af87b103bb40f41771891596",
+        "version" : "1.9.2"
+      }
+    },
+    {
+      "identity" : "swift-identified-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-identified-collections",
+      "state" : {
+        "revision" : "322d9ffeeba85c9f7c4984b39422ec7cc3c56597",
+        "version" : "1.1.1"
+      }
+    },
+    {
+      "identity" : "swift-navigation",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-navigation",
+      "state" : {
+        "revision" : "db6bc9dbfed001f21e6728fd36413d9342c235b4",
+        "version" : "2.3.0"
+      }
+    },
+    {
+      "identity" : "swift-perception",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-perception",
+      "state" : {
+        "revision" : "d924c62a70fca5f43872f286dbd7cef0957f1c01",
+        "version" : "1.6.0"
+      }
+    },
+    {
+      "identity" : "swift-protobuf",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-protobuf.git",
+      "state" : {
+        "revision" : "102a647b573f60f73afdce5613a51d71349fe507",
+        "version" : "1.30.0"
+      }
+    },
+    {
+      "identity" : "swift-sharing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-sharing",
+      "state" : {
+        "revision" : "732871fabfc6b38fcdff5ad2f7336327dbf78e81",
+        "version" : "2.4.0"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax",
+      "state" : {
+        "revision" : "f99ae8aa18f0cf0d53481901f88a0991dc3bd4a2",
+        "version" : "601.0.1"
+      }
+    },
+    {
+      "identity" : "xctest-dynamic-overlay",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
+      "state" : {
+        "revision" : "39de59b2d47f7ef3ca88a039dff3084688fe27f4",
+        "version" : "1.5.2"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Soongan/Tuist/Package.swift
+++ b/Soongan/Tuist/Package.swift
@@ -15,6 +15,12 @@ import PackageDescription
             "ComposableArchitecture": .framework,
             "ComposableArchitectureMacros": .macro,
             "Alamofire": .framework,
+            "FirebaseAnalytics": .framework,
+            "FirebaseMessaging": .framework,
+            "FirebaseCore": .framework,
+            "FirebaseCoreInternal": .framework,
+            "FirebaseInstallations": .framework,
+            "GoogleUtilities": .framework,
         ]
     )
 #endif

--- a/Soongan/Tuist/Package.swift
+++ b/Soongan/Tuist/Package.swift
@@ -14,6 +14,7 @@ import PackageDescription
             "KakaoSDKUser": .framework,
             "ComposableArchitecture": .framework,
             "ComposableArchitectureMacros": .macro,
+            "Alamofire": .framework,
         ]
     )
 #endif
@@ -27,5 +28,7 @@ let package = Package(
         
         .package(url: "https://github.com/kakao/kakao-ios-sdk", from: "2.24.0"),
         .package(url: "https://github.com/pointfreeco/swift-composable-architecture.git", from: "1.17.0"),
+        .package(url: "https://github.com/Alamofire/Alamofire.git", from: "5.8.1"),
+        .package(url: "https://github.com/firebase/firebase-ios-sdk.git", from: "10.24.0")
     ]
 )


### PR DESCRIPTION
## 📟 관련 이슈
- Resolved: #13

<br>

## 👷 작업한 내용
<!-- 작업한 내용을 적어주세요. -->
- 기본 네트워크 레이어 (Manager, Looger, Endpoint, Response, Interceptor) 을 포함한 CoreNetwork 모듈 구현
- Auth, FCM, Member, Notification, WeeklyContest, Report, Post Like 관련 EndPoint 및 DTO 구현
- 소셜로그인 로직을 담당하는 Core AppeLogin, KakaoLogin 모듈 구현
- 토큰 및 주요한 데이터를 저장하기 위한 CoreKeyChain 모듈 구현
- 각 API 에 대한 UI, 데이터 바인딩 구현

<br>

## 🚨 참고 사항
<!-- 참고 사항을 적어주세요. 없으면 지워주세요. -->

### 📡 네트워크 통신을 위한 Alamofire 채택

해당 프로젝트에서는 고화질 이미지를 다수 사용하는 만큼 안정적인 네트워크 통신이 필수적이라고 판단했습니다. URLSession을 직접 사용하여 구현할 수도 있지만, 복잡한 예외 처리나 백그라운드 네트워킹 등을 고려했을 때 이미 검증된 라이브러리인 Alamofire를 사용하는 것이 개발 효율성과 안정성 측면에서 더 유리하다고 생각했습니다.

---

### 🛠️ Endpoint 프로토콜 기반 설계

API가 추가되거나 변경될 때마다 URL, HTTP Method, Header 등을 수동으로 관리하는 것은 휴먼 에러를 유발할 수 있습니다. APIEndpoint 프로토콜을 채택하여 각 API의 명세를 하나의 타입으로 묶어 관리함으로써 코드의 가독성과 확장성을 높이고 실수를 줄이고자 했습니다.

``` swift
// 예시: Endpoint를 사용하여 API 요청을 명확하게 정의
let endpoint = AuthEndpoint.login(requestDTO)
let result = await NetworkManager.shared.request(endpoint)
```

---

### 🔗 Interceptor를 통한 흐름 제어

`AccessToken` 만료(401 Unauthorized)는 앱에서 흔히 발생하는 시나리오입니다. 이를 각 API 요청마다 처리하는 대신 `AuthInterceptor` 를 도입하여 토큰 갱신 및 요청 재시도 로직을 한 곳에서 자동으로 처리하도록 구현했습니다. 이를 통해 비즈니스 로직과 인증 로직을 분리하여 코드의 복잡도를 낮추고 유지보수성을 향상시켰습니다.

<br>

### 🚀 API 호출 방식

TCA(The Composable Architecture)의 Reducer 내에서 사이드 이펙트를 처리하기 위해 .run 이펙트를 사용합니다. API 호출과 같은 비동기 작업은 다음과 같은 방식을 통해 이루어집니다.

1. 액션 트리거: 사용자의 입력(예: 버튼 탭)으로 특정 액션이 발생합니다.

2. .run 이펙트 실행: 해당 액션의 Reduce 클로저 내에서 .run을 반환하여 비동기 작업을 시작합니다. 이 스코프 안에서 NetworkManager를 통해 실제 API를 호출합니다.

3. 결과 처리 및 액션 전송: API 호출의 결과(Result)에 따라, 성공 또는 실패에 해당하는 새로운 액션을 await send(...)를 통해 시스템에 다시 전달합니다.

4. 상태 업데이트: 성공/실패 액션을 받은 Reducer는 앱의 State를 변경합니다. 예를 들어, 에러 메시지를 표시하거나 다음 화면으로 이동시킵니다.

#### 실제 구현 예시

``` swift
// LoginFeature.swift

case .kakaoButtonTapped:
    return .run { send in
        do {
            let idToken = try await kakaoLoginService.login()
            await send(.socialLoginSuccessResponse(type: .kakao, token: idToken)) // 성공 시 다음 액션 전송
        } catch {
            await send(.socialLoginFailureResponse(error)) // 실패 시 에러 액션 전송
        }
    }
```

1. 사용자가 카카오 로그인 버튼을 누르면 `.kakaoButtonTapped` 액션이 호출됩니다.
2. .run 이펙트가 실행되어 카카오 SDK로부터 idToken을 받아오고, 성공 시 `.socialLoginSuccessResponse` 액션을 전송합니다.


``` swift
// LoginFeature.swift

case let .socialLoginSuccessResponse(type, token):
    return .run { send in
        // ... NetworkManager를 사용한 API 요청 ...
        let result: Result<AuthedResponseDTO, NetworkError> = await NetworkManager.shared.request(...)

        switch result {
        case .success(let authedResult):
            // ... 키체인에 토큰 저장 ...
            await send(.loginSuccess) // 최종 성공 액션

        case .failure(let error):
            await send(.loginFailure(error)) // 최종 실패 액션
        }
    }
```

3. `.socialLoginSuccessResponse` 액션은 다시 `.run` 이펙트를 실행하여 저희 서버에 로그인을 요청합니다.
4. 서버 요청 결과에 따라 `.loginSuccess` 또는 `.loginFailure` 액션을 호출합니다.

``` swift
// LoginFeature.swift

case .loginSuccess:
    state.path.append(.signup(SignupFeature.State())) // 성공 시 화면 전환
    return .none

case .loginFailure(let error):
    state.errorMessage = "로그인 실패: \(error.localizedDescription)" // 실패 시 에러 메시지 바인딩
    return .none
```

5. 마지막으로, `.loginSuccess`나 `.loginFailure` 액션을 받은 `Reducer` 가 화면 전환이나 에러 메시지 표시 등 `State` 를 직접 변경합니다.
<br>

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
