### PR TITLE
[Feat] #23 - 신고하기 관련 로직 및 UI 수정

### DIFF
--- a/Soongan/Core/CoreNetwork/Sources/PostLike/DTO/Request/PostLikeRequestDTO.swift
+++ b/Soongan/Core/CoreNetwork/Sources/PostLike/DTO/Request/PostLikeRequestDTO.swift
@@ -8,10 +8,10 @@
 import Foundation
 
 public struct PostLikeRequestDTO: Encodable {
-    let postId: String
+    let postId: Int
     let contestType: String
     
-    public init(postId: String, contestType: String) {
+    public init(postId: Int, contestType: String) {
         self.postId = postId
         self.contestType = contestType
     }

--- a/Soongan/Core/CoreNetwork/Sources/Report/DTO/Response/ReportResponseDTO.swift
+++ b/Soongan/Core/CoreNetwork/Sources/Report/DTO/Response/ReportResponseDTO.swift
@@ -14,6 +14,6 @@ public struct ReportResponseDTO: Decodable {
     let targetId: Int
     let targetType: String
     let reportType: String
-    let reason: String
+    let reason: String?
     let reportHistories: [ReportHistoryData]
 }

--- a/Soongan/Core/CoreNetwork/Sources/WeeklyContest/DTO/Response/SearchDetailContestResponseDTO.swift
+++ b/Soongan/Core/CoreNetwork/Sources/WeeklyContest/DTO/Response/SearchDetailContestResponseDTO.swift
@@ -9,6 +9,7 @@ import Foundation
 
 public struct SearchDetailContestResponseDTO: Decodable {
     public let memberId: Int?
+    public let authorMemberId: Int
     public let postId: Int
     public let title: String
     public let imageUrl: String

--- a/Soongan/Core/CoreNetwork/Sources/WeeklyContest/WeeklyContestEndpoint.swift
+++ b/Soongan/Core/CoreNetwork/Sources/WeeklyContest/WeeklyContestEndpoint.swift
@@ -11,9 +11,9 @@ import Foundation
 public enum WeeklyContestEndpoint {
     case getContest(SearchWeeklyContestRequestDTO)
     case postContest(PostWeeklyContestRequestDTO)
-    case getDetailContest(postId: String)
-    case deleteContest(postId: String)
-    case patchContest(postId: String)
+    case getDetailContest(postId: Int)
+    case deleteContest(postId: Int)
+    case patchContest(postId: Int)
     case getContestList
     case getMyContest(SearchMyContestRequestDTO)
 }

--- a/Soongan/DesignSystem/Sources/Component/CustomSheetView.swift
+++ b/Soongan/DesignSystem/Sources/Component/CustomSheetView.swift
@@ -122,32 +122,54 @@ public struct CustomSheetView<T: Equatable & CaseIterable>: View {
                 .padding(.top, 12)
                 
             case .spam:
-                reportContentSection(reportType: .spam, action: {})
+                reportContentSection(reportType: .spam, action: { type in
+                    reportAction?(type, "")
+                })
                     .padding(.top, 40)
                 
-            case .infringement:
-                ReportInputReasonConestSection(action: reportAction ?? { _, _ in }, type: .infringement)
-                .padding(.top, 40)
+            case .infringement(let inputState):
+                if inputState {
+                    reportContentSection(reportType: .infringement, action: { type in
+                        reportAction?(type, "")
+                    })
+                        .padding(.top, 40)
+                } else {
+                    ReportInputReasonConestSection(action: reportAction ?? { _, _ in }, type: .infringement)
+                    .padding(.top, 40)
+                }
                 
             case .inappropriateContent:
-                reportContentSection(reportType: .inappropriateContent, action: {})
+                reportContentSection(reportType: .inappropriateContent, action: { type in
+                    reportAction?(type, "")
+                })
                     .padding(.top, 40)
                 
             case .hateSpeech:
-                reportContentSection(reportType: .hateSpeech, action: {})
+                reportContentSection(reportType: .hateSpeech, action: { type in
+                    reportAction?(type, "")
+                })
+                    .padding(.top, 40)
+                
+            case .promotion:
+                reportContentSection(reportType: .promotion, action: { type in
+                    reportAction?(type, "")
+                })
                     .padding(.top, 40)
                 
             case .reportComplete(let type):
                 reportCompleteContentSection(type: type, action: {})
                     .padding(.top, 40)
-                
-            case .promotion:
-                reportContentSection(reportType: .promotion, action: {})
-                    .padding(.top, 40)
             
-            case .other:
-                ReportInputReasonConestSection(action: reportAction ?? { _, _ in }, type: .other)
-                .padding(.top, 40)
+            case .other(let inputState):
+                if inputState {
+                    reportContentSection(reportType: .other, action: { type in
+                        reportAction?(type, "")
+                    })
+                        .padding(.top, 40)
+                } else {
+                    ReportInputReasonConestSection(action: reportAction ?? { _, _ in }, type: .other)
+                    .padding(.top, 40)
+                }
                 
             case .detailContestOption(let isWriter):
                 detailContestOptionSection(isWriter: isWriter, action: { optionType in
@@ -174,7 +196,7 @@ public struct CustomSheetView<T: Equatable & CaseIterable>: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         .presentationDetents(type.height)
-        .presentationBackground(Color.white)
+        .presentationBackground(DesignSystem.Color.soonganBG)
         .presentationCornerRadius(20)
     }
 }
@@ -550,23 +572,21 @@ private extension CustomSheetView {
         }
     }
     
-    func reportContentSection(reportType: ContestReportReasonType, action: @escaping () -> Void) -> some View {
+    func reportContentSection(reportType: ContestReportReasonType, action: @escaping (_ type: ContestReportReasonType) -> Void) -> some View {
         VStack(spacing: 0) {
             VStack(alignment: .leading, spacing: 4) {
-                Text("이 댓글을")
-                    .font(DesignSystem.Font.regular16, lineHeight: 24)
+                Text("이 게시물을")
                 
                 HStack(spacing: 0) {
                     Text(reportType.title)
                         .font(DesignSystem.Font.bold16, lineHeight: 24)
                     
                     Text("(으)로")
-                        .font(DesignSystem.Font.regular16, lineHeight: 24)
                 }
                 
                 Text("정말 신고하겠습니까?")
-                    .font(DesignSystem.Font.regular16, lineHeight: 24)
             }
+            .font(DesignSystem.Font.regular16, lineHeight: 24)
             .padding(.horizontal, 4)
             .foregroundStyle(Color.black100)
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -575,7 +595,7 @@ private extension CustomSheetView {
             CustomBottomButton(
                 type: .comfirm,
                 action: {
-                    action()
+                    action(reportType)
                     dismiss()
                 }
             )
@@ -587,17 +607,24 @@ private extension CustomSheetView {
     func reportCompleteContentSection(type: ContestReportReasonType, action: @escaping () -> Void) -> some View {
         VStack(spacing: 0) {
             VStack(alignment: .leading, spacing: 0) {
-                Text("신고가 완료됐습니다.\n\n해당 게시물은 숨김처리되었습니다.\n\n3일 이내로 검토 후 조치가 이뤄질 예정입니다. 결과가 나오면 알림으로 알려드리겠습니다.")
-                    .padding(.bottom, 20)
+                Text("신고가 완료됐습니다.\n")
+                    .font(DesignSystem.Font.regular16, lineHeight: 24)
                 
-                if type == .infringement {
-                    Text("신고 내용의 구체적인 확인이 더 필요한 경우\n이메일로 연락드릴 예정입니다.")
+                Text("해당 게시물은 숨김처리되었습니다.\n")
+                    .font(DesignSystem.Font.regular16, lineHeight: 24)
+                
+                Text("3일 이내로 검토 후 조치가 이뤄질 예정입니다. 결과가 나오면 알림으로 알려드리겠습니다.")
+                    .font(DesignSystem.Font.regular16, lineHeight: 24)
+                
+                if type == .infringement || type == .other  {
+                    Text("\n신고 내용의 구체적인 확인이 더 필요한 경우\n이메일로 연락드릴 예정입니다.")
+                        .font(DesignSystem.Font.regular16, lineHeight: 24)
                         .underline(color: DesignSystem.Color.black100)
                 }
-                Text("감사합니다")
                 
+                Text("감사합니다.")
+                    .font(DesignSystem.Font.regular16, lineHeight: 24)
             }
-            .font(DesignSystem.Font.regular16, lineHeight: 24)
             .foregroundStyle(DesignSystem.Color.black100)
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.horizontal, 4)

--- a/Soongan/DesignSystem/Sources/Component/CustomTextEditor.swift
+++ b/Soongan/DesignSystem/Sources/Component/CustomTextEditor.swift
@@ -34,11 +34,11 @@ public struct CustomTextEditor: View {
     public var body: some View {
         ZStack(alignment: .topLeading) {
             TextEditor(text: $text)
+                .font(DesignSystem.Font.regular16, lineHeight: 20)
                 .scrollContentBackground(.hidden)
                 .background(DesignSystem.Color.soonganBG)
                 .padding(10)
                 .focused($isFocused)
-                .font(DesignSystem.Font.regular16)
                 .onChange(of: text) { _, newValue in
                     if newValue.count > characterLimit {
                         text = String(newValue.prefix(characterLimit))
@@ -50,7 +50,7 @@ public struct CustomTextEditor: View {
                 Text(placeholder)
                     .font(DesignSystem.Font.regular16)
                     .foregroundColor(DesignSystem.Color.black60)
-                    .padding(15)
+                    .padding(16)
                     .allowsHitTesting(false)
             }
             

--- a/Soongan/DesignSystem/Sources/Component/ImageGridView.swift
+++ b/Soongan/DesignSystem/Sources/Component/ImageGridView.swift
@@ -122,11 +122,11 @@ public struct ImageGridView: View {
 //}
 
 public struct ContestImageModel: Identifiable, Hashable {
-    public var id: String
+    public var id: Int
     public let imageUrl: String
     public let nickname: String?
     
-    public init(id: String, imageUrl: String, nickname: String? = nil) {
+    public init(id: Int, imageUrl: String, nickname: String? = nil) {
         self.id = id
         self.imageUrl = imageUrl
         self.nickname = nickname

--- a/Soongan/DesignSystem/Sources/Enum/ContestReportReasonType.swift
+++ b/Soongan/DesignSystem/Sources/Enum/ContestReportReasonType.swift
@@ -8,12 +8,23 @@
 import Foundation
 
 public enum ContestReportReasonType: CaseIterable {
-    case inappropriateContent      // 부적절한 사진 게시 및 언행
-    case hateSpeech                // 욕설, 혐오, 비하 등이 포함된 표현
-    case infringement              // 도용, 초상권, 저작권 등 타인의 권리 침해
-    case spam                      // 도배
-    case promotion                 // 홍보용 사진 혹은 댓글 게시
-    case other                     // 기타
+    /// 부적절한 사진 게시 및 언행
+    case inappropriateContent
+    
+    /// 욕설, 혐오, 비하 등이 포함된 표현
+    case hateSpeech
+    
+    /// 도용, 초상권, 저작권 등 타인의 권리 침해
+    case infringement
+    
+    /// 도배
+    case spam
+    
+    /// 홍보용 사진 혹은 댓글 게시
+    case promotion
+    
+    /// 기타
+    case other
     
     var title: String {
         switch self {

--- a/Soongan/DesignSystem/Sources/Enum/SheetContentType.swift
+++ b/Soongan/DesignSystem/Sources/Enum/SheetContentType.swift
@@ -18,11 +18,11 @@ public enum SheetContentType: Identifiable, Equatable {
     case alarmSetting
     case contestReport
     case spam
-    case infringement
+    case infringement(inputState: Bool)
     case inappropriateContent
     case hateSpeech
     case promotion
-    case other
+    case other(inputState: Bool)
     case reportComplete(type: ContestReportReasonType)
     case detailContestOption(isWriter: Bool)
     case sortContest
@@ -75,8 +75,16 @@ public enum SheetContentType: Identifiable, Equatable {
         case .alarmSetting: return [.height(380)]
         case .contestReport: return [.height(432)]
         case .spam, .inappropriateContent, .hateSpeech, .promotion: return [.height(288)]
-        case .infringement, .other: return [.height(404)]
-        case .reportComplete: return [.height(456)]
+        case .infringement(let inputState), .other(let inputState):
+            return inputState == true ? [.height(288)] : [.height(390)]
+            
+        case .reportComplete(let type):
+            switch type {
+            case .infringement, .other:
+                return [.height(456)]
+            default:
+                return [.height(384)]
+            }
         case .detailContestOption, .sortContest: return [.height(240)]
         case .selectProfile: return [.height(165)]
         }

--- a/Soongan/Feature/AllTimeContestFeature/Sources/Logic/AllTimeContestFeature.swift
+++ b/Soongan/Feature/AllTimeContestFeature/Sources/Logic/AllTimeContestFeature.swift
@@ -106,7 +106,7 @@ public struct AllTimeContestFeature {
                     return .none
                     
                 case .detailContest(.delegate(.showContestDetail(let postId))):
-                    state.path.append(.contestDetail(ContestDetailFeature.State(postId: String(postId))))
+                    state.path.append(.contestDetail(ContestDetailFeature.State(postId: postId)))
                     return .none
                     
                 case .detailContest(.delegate(.moveToContestTab)):

--- a/Soongan/Feature/AuthFeature/Sources/Logic/LoginFeature.swift
+++ b/Soongan/Feature/AuthFeature/Sources/Logic/LoginFeature.swift
@@ -10,6 +10,7 @@ import SwiftUI
 import CoreAppleLogin
 import CoreKakaoLogin
 import CoreKeyChain
+import CoreUserDefault
 import CoreNetwork
 import DesignSystem
 import Shared
@@ -50,6 +51,7 @@ public struct LoginFeature {
     
     @Dependency(\.appleLoginService) var appleLoginService
     @Dependency(\.kakaoLoginService) var kakaoLoginService
+    @Dependency(\.userDefaultsClient) var userDefaultsClient
     @Dependency(\.openURL) var openURL
     
     // MARK: - Action
@@ -146,6 +148,9 @@ public struct LoginFeature {
                         if myResult.nickname == nil && myResult.birthYear == nil {
                             await send(.isSignupComplete(false))
                         } else {
+                            if let nickname = myResult.nickname {
+                                await userDefaultsClient.setString(nickname, forKey: UserDefaultKeys.User.username.rawValue)
+                            }
                             await send(.isSignupComplete(true))
                         }
                         
@@ -195,13 +200,8 @@ public struct LoginFeature {
                 return .none
             
             case .path(.element(id: _, action: .signupSuccess(.delegate(.showMainTab)))):
-                print("LoginFeature 로 데이터 옴")
                 return .send(.delegate(.loginSuccess))
-//            case .path(.element(id: _, action: .signupSuccess(T##SignupSuccessFeature.Action)))
-//            case .path(.element(id: _, action: .signup(.showSignupView))):
-//                state.path.append(.signup(SignupFeature.State()))
-//                return .none
-                
+
             case .path(.element(id: _, action: .signup(.backButtonTapped))):
                 state.path.removeLast()
                 return .none

--- a/Soongan/Feature/ContestFeature/Sources/Logic/ContestFeature.swift
+++ b/Soongan/Feature/ContestFeature/Sources/Logic/ContestFeature.swift
@@ -78,7 +78,7 @@ public struct ContestFeature {
         case chagneContestIndex
         case dismissContestSheet(Bool)
         case dismissSortContestSheet(Bool)
-        case contestDetailImageTapped(String)
+        case contestDetailImageTapped(Int)
         case sortContestContentTapped
         case changeSortContestType(SortContestDataType)
     }
@@ -146,7 +146,7 @@ public struct ContestFeature {
                 state.rightContestImageList.removeAll()
                 
                 for (index, item) in response.posts.enumerated() {
-                    let model = ContestImageModel(id: String(item.postId), imageUrl: item.imageUrl, nickname: item.nickname)
+                    let model = ContestImageModel(id: item.postId, imageUrl: item.imageUrl, nickname: item.nickname)
                     if index % 2 == 0 {
                         state.leftContestImageList.append(model)
                     } else {

--- a/Soongan/Feature/DetailContestFeature/Sources/Logic/ContestDetailFeature.swift
+++ b/Soongan/Feature/DetailContestFeature/Sources/Logic/ContestDetailFeature.swift
@@ -316,7 +316,15 @@ public struct ContestDetailFeature {
                 
             case .reportReasonButtonTapped(let type, let reason):
                 state.reportReason = reason
-                state.activeSheet = type == .other ? .other(inputState: true) : .infringement(inputState: true)
+
+                switch type {
+                  case .other:
+                      state.activeSheet = .other(inputState: true)
+                  case .infringement:
+                      state.activeSheet = .infringement(inputState: true)
+                  default:
+                      break
+                  }
                 
                 return .none
                 

--- a/Soongan/Feature/DetailContestFeature/Sources/Logic/ContestDetailFeature.swift
+++ b/Soongan/Feature/DetailContestFeature/Sources/Logic/ContestDetailFeature.swift
@@ -21,8 +21,8 @@ public struct ContestDetailFeature {
     
     @ObservableState
     public struct State: Equatable {
-        var postId: String
-        var userId: Int?
+        var postId: Int
+        var postUserId: Int?
         var myNickname: String?
         
         var contestTitle: String?
@@ -30,6 +30,8 @@ public struct ContestDetailFeature {
         var contestAuthor: String?
         var isLiked: Bool?
         var likeCount: String?
+        
+        var reportReason: String?
         
         var isDeleteAlertPresented: Bool = false
         var isDeleteCompleteAlertPresented: Bool = false
@@ -40,13 +42,14 @@ public struct ContestDetailFeature {
         
         var activeSheet: SheetContentType?
         var reportReasonSheet: SheetContentType?
+        var completeReportSheet: SheetContentType?
         
         var isWriter: Bool {
             return myNickname == contestAuthor
         }
         
         public init (
-            postId: String
+            postId: Int
         ) {
             self.postId = postId
         }
@@ -67,8 +70,8 @@ public struct ContestDetailFeature {
         
         case onAppear
         case reportReasonButtonTapped(type: ContestReportReasonType, reason: String)
-        case postReport(type: ContestReportReasonType, reason: String?)
-        case reportSuccess(ReportResponseDTO)
+        case postReport(type: ContestReportReasonType)
+        case reportSuccess(ReportResponseDTO, ContestReportReasonType)
         
         case likeButtonTapped
         case optionButtonTapped
@@ -78,6 +81,7 @@ public struct ContestDetailFeature {
         
         case reportSheetIsPresented
         case optionSheetIsPresented(ContestReportReasonType)
+        case completeReportSheetIsPresented(ContestReportReasonType)
         case dismissOptionSheet(Bool)
         case dismissReportOptionSheet(Bool)
         case dismissFullSizeImageSheet(Bool)
@@ -130,7 +134,7 @@ public struct ContestDetailFeature {
                 }
                 
             case .onAppearSuccess(let response):
-                state.userId = response.memberId
+                state.postUserId = response.authorMemberId
                 state.contestTitle = response.title
                 state.contestAuthor = response.nickname
                 state.imageUrl = response.imageUrl
@@ -156,7 +160,7 @@ public struct ContestDetailFeature {
                     state.activeSheet = .hateSpeech
                     
                 case .infringement:
-                    state.activeSheet = .infringement
+                    state.reportReasonSheet = .infringement(inputState: false)
                     
                 case .spam:
                     state.activeSheet = .spam
@@ -165,8 +169,13 @@ public struct ContestDetailFeature {
                     state.activeSheet = .promotion
                     
                 case .other:
-                    state.activeSheet = .other
+                    state.reportReasonSheet = .other(inputState: false)
                 }
+                
+                return .none
+                
+            case .completeReportSheetIsPresented(let type):
+                state.completeReportSheet = .reportComplete(type: type)
                 
                 return .none
                 
@@ -282,14 +291,12 @@ public struct ContestDetailFeature {
             case .backButtonTapped:
                 return .send(.delegate(.backConfirmed))
                 
-            case .postReport(let type, let reason):
-                guard let id = state.userId else { return .none }
-                
+            case .postReport(let type):
                 let dto = ReportRequestDTO(
-                    targetId: id,
+                    targetId: state.postId,
                     targetType: "WEEKLY_POST",
                     reportType: type.typeTitle,
-                    reason: reason
+                    reason: state.reportReason
                 )
                 
                 return .run { send in
@@ -297,18 +304,21 @@ public struct ContestDetailFeature {
                     
                     switch result {
                     case .success(let responseResult):
-                        await send(.reportSuccess(responseResult))
+                        await send(.reportSuccess(responseResult, type))
                     case .failure(let error):
                         break
                     }
                 }
                 
-            case .reportSuccess(let response):
-                
-                return .none
+            case .reportSuccess(let response, let type):
+                state.reportReason = nil
+                return .send(.completeReportSheetIsPresented(type))
                 
             case .reportReasonButtonTapped(let type, let reason):
-                return .send(.postReport(type: type, reason: reason))
+                state.reportReason = reason
+                state.activeSheet = type == .other ? .other(inputState: true) : .infringement(inputState: true)
+                
+                return .none
                 
             default:
                 return .none

--- a/Soongan/Feature/DetailContestFeature/Sources/View/ContestDetailView.swift
+++ b/Soongan/Feature/DetailContestFeature/Sources/View/ContestDetailView.swift
@@ -29,9 +29,6 @@ public struct ContestDetailView: View {
     
     public var body: some View {
         baseView
-            .onAppear {
-                store.send(.onAppear)
-            }
             .ignoresSafeArea(edges: .bottom)
             .background(DesignSystem.Color.soonganBG)
             .background(InteractivePopGestureEnabler())
@@ -79,31 +76,16 @@ public struct ContestDetailView: View {
             }
             .sheet(item: $store.activeSheet) { sheetType in
                 CustomSheetView<ContestReportReasonType>(type: sheetType) { type, reportReason in
-                    
-                    switch type {
-                    case .inappropriateContent:
-                        store.isReportInputReasonSheetPresented = true
-                    case .hateSpeech:
-                        break
-                    case .infringement:
-                        break
-                    case .spam:
-                        break
-                    case .promotion:
-                        break
-                    case .other:
-                        store.isReportInputReasonSheetPresented = true
-                    }
+                    store.send(.postReport(type: type))
                 }
             }
-            .sheet(
-                isPresented: $store.isReportInputReasonSheetPresented.sending(\.dismissReportOptionSheet)
-            ) {
-                if let type = store.reportReasonSheet {
-                    CustomSheetView<NeverOption>(type: type) { reportType, reasonText in
-                        store.send(.reportReasonButtonTapped(type: reportType, reason: reasonText))
-                    }
+            .sheet(item: $store.reportReasonSheet) { sheetType in
+                CustomSheetView<NeverOption>(type: sheetType) { reportType, reasonText in
+                    store.send(.reportReasonButtonTapped(type: reportType, reason: reasonText))
                 }
+            }
+            .sheet(item : $store.completeReportSheet) { sheetType in
+                CustomSheetView<ContestReportReasonType>(type: sheetType) { _ in }
             }
             .fullScreenCover(
                 isPresented: $store.isFullSizeImageSheetPresented.sending(\.dismissFullSizeImageSheet)
@@ -213,7 +195,7 @@ public struct ContestDetailView: View {
     NavigationStack {
         ContestDetailView(
             store: Store(initialState:
-                            ContestDetailFeature.State(postId: String(10))) {
+                            ContestDetailFeature.State(postId: 10)) {
                                 ContestDetailFeature()
                             }
         )

--- a/Soongan/Feature/HomeFeature/Sources/Logic/HomeFeature.swift
+++ b/Soongan/Feature/HomeFeature/Sources/Logic/HomeFeature.swift
@@ -139,7 +139,7 @@ public struct HomeFeature {
                 return .none
                 
             case .pictureTapped(let id):
-                state.path.append(.contestDetail(ContestDetailFeature.State(postId: String(id))))
+                state.path.append(.contestDetail(ContestDetailFeature.State(postId: id)))
                 
                 return .none
                 

--- a/Soongan/Feature/MypageFeature/Sources/Logic/MypageFeature.swift
+++ b/Soongan/Feature/MypageFeature/Sources/Logic/MypageFeature.swift
@@ -91,7 +91,7 @@ public struct MypageFeature {
         
         case myInfoActionSuccess(MyprofileOptionType)
         case successSheetComplete(MypageSuccessSheetType)
-        case contestDetailImageTapped(String)
+        case contestDetailImageTapped(Int)
         
         case deleteMyInfomation
         
@@ -147,7 +147,7 @@ public struct MypageFeature {
                 state.rightContestImageList.removeAll()
                 
                 for (index, item) in response.postInfo.enumerated() {
-                    let model = ContestImageModel(id: String(item.postId), imageUrl: item.imageUrl)
+                    let model = ContestImageModel(id: item.postId, imageUrl: item.imageUrl)
                     if index % 2 == 0 {
                         state.leftContestImageList.append(model)
                     } else {
@@ -160,6 +160,10 @@ public struct MypageFeature {
             case let .path(.element(id: _, action: action)):
                 switch action {
                 case .editProfile(.backButtonTapped), .editProfile(.delegate(.backButtonTapped)), .alarmList(.backButtonTapped), .questionsList(.backButtonTapped):
+                    state.path.removeLast()
+                    return .none
+                    
+                case .contestDetail(.delegate(.backConfirmed)):
                     state.path.removeLast()
                     return .none
                     

--- a/Soongan/Soongan/Soongan.entitlements
+++ b/Soongan/Soongan/Soongan.entitlements
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>aps-environment</key>
+	<string>development</string>
 	<key>com.apple.developer.applesignin</key>
 	<array>
 		<string>Default</string>

--- a/Soongan/Soongan/Sources/SoonganApp.swift
+++ b/Soongan/Soongan/Sources/SoonganApp.swift
@@ -122,12 +122,12 @@ extension AppDelegate: MessagingDelegate {
         }
         
         // 토큰이 변경되었음을 알리는 노티피케이션 발송
-        let dataDict: [String: String] = ["token": fcmToken ?? ""]
-        NotificationCenter.default.post(
-            name: Notification.Name("FCMToken"),
-            object: nil,
-            userInfo: dataDict
-        )
+//        let dataDict: [String: String] = ["token": fcmToken ?? ""]
+//        NotificationCenter.default.post(
+//            name: Notification.Name("FCMToken"),
+//            object: nil,
+//            userInfo: dataDict
+//        )
         
         // 서버에 토큰 전송 (필요시)
         Task {
@@ -205,7 +205,7 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         
         let userInfo = response.notification.request.content.userInfo
         print("알림 탭:", userInfo)
-//        decodeUserInfo(userInfo)
+        decodeUserInfo(userInfo)
         
         // TODO: 알림 탭 시 특정 화면으로 이동하는 로직 구현
         


### PR DESCRIPTION
## 📟 관련 이슈
- Resolved: #23 

<br>

## 👷 작업한 내용
<!-- 작업한 내용을 적어주세요. -->
- 신고하기 기능에서 각 사유(Type)에 따라 다른 UI(Sheet)가 나타나고 서버로 전송되는 데이터 로직이 올바르게 처리되도록 수정
- '저작권 침해'와 '기타' 사유의 경우 사용자가 직접 내용을 입력할 수 있는 UI를 제공하고 해당 입력값을 서버로 전송하는 기능을 구현
- 신고 완료 후 나타나는 결과 화면(Sheet)도 각 사유에 따라 다른 높이를 갖도록 개선
- `LoginFeature` 에서 로그인 성공 후 사용자 닉네임을 `UserDefaults` 에 저장하는 로직을 추가

<br>

## 📸 스크린샷
|기능|신고하기 기능|
|:--:|:--:|
|Img|<img src = "https://github.com/user-attachments/assets/09cfc37b-27d2-454a-8507-41035fc1c5e3" width ="250">|

<br>

## 🚨 참고 사항
<!-- 참고 사항을 적어주세요. 없으면 지워주세요. -->

  - `SheetContentType` Enum의 동적 높이 조절:
       - SheetContentType에 inputState라는 연관값(associated value)을 추가하여, 신고 사유 입력 Sheet의 상태(입력 전/후)에 따라 동적으로 높이가 조절되도록 구현했습니다.
       - .infringement(inputState: Bool) 케이스는 사용자가 '직접 입력' 버튼을 누르면 inputState가 true로 변경되면서 Sheet의 높이가 줄어드는 방식입니다.
       
   - TCA `reportReason` 상태 관리:
       - `ContestDetailFeature` 내에 `reportReason` 변수를 추가하여 사용자가 '기타' 또는 '저작권 침해' 사유를 입력할 때 해당 텍스트를 임시로 저장하도록 했습니다.
       - 이후 '신고하기' 버튼을 누르면 `postReport` 액션이 이 `reportReason` 상태를 참조하여 서버로 데이터를 전송합니다. 이는 여러 단계에 걸친 사용자 입력을 하나의 상태로 관리하기 위한 로직입니다.

   - `LoginFeature`의 `UserDefaults` 저장 시점:
       - 기존에는 회원가입 시에만 닉네임을 UserDefaults에 저장했지만 이번 변경으로 로그인 성공 시점에도 서버에서 받아온 사용자 정보를 UserDefaults에 저장하도록 로직을 추가했습니다.
       - 이는 앱을 재시작하거나 재로그인했을 때 사용자 정보가 누락되는 엣지 케이스를 방지하고 앱 전반에서 사용자 데이터를 일관성 있게 유지하기 위함입니다.

<br>

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
