### PR TITLE
[Feat] #25 - 인증되지 않은 유저에 대한 둘러보기 플로우 구현

### DIFF
--- a/Soongan/DesignSystem/Sources/Component/CustomAlertView.swift
+++ b/Soongan/DesignSystem/Sources/Component/CustomAlertView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 public struct CustomAlertView: View {
     
     private var type: AlertType
-
+    private var onBackgroundTap: (() -> Void)?
     private var centerButtonAction: (() -> Void)?
     private var leftButtonAction: (() -> Void)?
     private var rightButtonAction: (() -> Void)?
@@ -19,11 +19,13 @@ public struct CustomAlertView: View {
     
     public init(
         type: AlertType,
+        onBackgroundTap: (() -> Void)? = nil,
         centerButtonAction: (() -> Void)? = nil,
         leftButtonAction: (() -> Void)? = nil,
         rightButtonAction: (() -> Void)? = nil
     ) {
         self.type = type
+        self.onBackgroundTap = onBackgroundTap
         self.centerButtonAction = centerButtonAction
         self.leftButtonAction = leftButtonAction
         self.rightButtonAction = rightButtonAction
@@ -36,6 +38,9 @@ public struct CustomAlertView: View {
             DesignSystem.Color.black100
                 .opacity(0.5)
                 .ignoresSafeArea()
+                .onTapGesture {
+                    onBackgroundTap?()
+                }
             
             VStack {
                 Image.soonganLogo

--- a/Soongan/Feature/AllTimeContestFeature/Sources/Logic/AllTimeContestFeature.swift
+++ b/Soongan/Feature/AllTimeContestFeature/Sources/Logic/AllTimeContestFeature.swift
@@ -62,6 +62,7 @@ public struct AllTimeContestFeature {
                 
         public enum Delegate {
             case moveToContestTab
+            case logoutRequested
         }
     }
     
@@ -104,6 +105,9 @@ public struct AllTimeContestFeature {
                 case .contestDetail(.backButtonTapped):
                     state.path.removeLast()
                     return .none
+                    
+                case .contestDetail(.delegate(.didRequestLogout)):
+                    return .send(.delegate(.logoutRequested))
                     
                 case .detailContest(.delegate(.showContestDetail(let postId))):
                     state.path.append(.contestDetail(ContestDetailFeature.State(postId: postId)))

--- a/Soongan/Feature/ContestFeature/Sources/Logic/ContestFeature.swift
+++ b/Soongan/Feature/ContestFeature/Sources/Logic/ContestFeature.swift
@@ -81,6 +81,12 @@ public struct ContestFeature {
         case contestDetailImageTapped(Int)
         case sortContestContentTapped
         case changeSortContestType(SortContestDataType)
+        
+        case delegate(DelegateAction)
+
+        public enum DelegateAction {
+            case logoutRequested
+        }
     }
     
     // MARK: - Body
@@ -166,6 +172,8 @@ public struct ContestFeature {
                 case .contestDetail(.delegate(.backConfirmed)):
                     state.path.removeLast()
                     return .none
+                case .contestDetail(.delegate(.didRequestLogout)):
+                    return .send(.delegate(.logoutRequested))
                 default:
                     return .none
                 }
@@ -208,6 +216,9 @@ public struct ContestFeature {
                 state.isSortSheetPresented = false
                 
                 return .send(.fetchContestPosts)
+                
+            case .delegate:
+                return .none
                 
             default:
                 return .none

--- a/Soongan/Feature/DetailContestFeature/Sources/Logic/ContestDetailFeature.swift
+++ b/Soongan/Feature/DetailContestFeature/Sources/Logic/ContestDetailFeature.swift
@@ -226,7 +226,7 @@ public struct ContestDetailFeature {
                     case .success(let responseResult):
                         await send(.networkAction(.likeContestSuccess(isLike: isLiked, responseResult)))
                     case .failure(let error):
-                        await send(.networkAction(.onAppearDetailContestFailure(error)))
+                        await send(.networkAction(.likeContestFailure(error)))
                     }
                 }
             
@@ -234,6 +234,10 @@ public struct ContestDetailFeature {
                 state.likeCount = formatLikeCount(response.likeCount)
                 state.isLiked = !isLike
                 
+                return .none
+            
+            case .networkAction(.likeContestFailure(let error)):
+                // TODO: - 좋아요 에러
                 return .none
                 
             case .deleteButtonTapped:

--- a/Soongan/Feature/DetailContestFeature/Sources/Logic/ContestDetailFeature.swift
+++ b/Soongan/Feature/DetailContestFeature/Sources/Logic/ContestDetailFeature.swift
@@ -21,6 +21,8 @@ public struct ContestDetailFeature {
     
     @ObservableState
     public struct State: Equatable {
+        @Shared(.appStorage("AuthState")) var authState: AuthType = .loggedOut
+        
         var postId: Int
         var postUserId: Int?
         var myNickname: String?
@@ -39,6 +41,7 @@ public struct ContestDetailFeature {
         var isReportOptionSheetPresented: Bool = false
         var isFullSizeImageSheetPresented: Bool = false
         var isReportInputReasonSheetPresented: Bool = false
+        var isLoginAlertPresented: Bool = false
         
         var activeSheet: SheetContentType?
         var reportReasonSheet: SheetContentType?
@@ -68,13 +71,15 @@ public struct ContestDetailFeature {
     public enum Action: BindableAction {
         case binding(BindingAction<State>)
         
+        case alertAction(AlertAction)
+        case networkAction(NetworkAction)
+        case uiAction(UIAction)
+        
         case onAppear
         case reportReasonButtonTapped(type: ContestReportReasonType, reason: String)
         case postReport(type: ContestReportReasonType)
         case reportSuccess(ReportResponseDTO, ContestReportReasonType)
         
-        case likeButtonTapped
-        case optionButtonTapped
         case deleteOptionButtonTapped
         case deleteButtonTapped
         case contestImageTapped
@@ -91,19 +96,37 @@ public struct ContestDetailFeature {
         
         case backButtonTapped
         
-        case onAppearSuccess(SearchDetailContestResponseDTO)
-        case likeButtonTappedSuccess(isLike: Bool, PostLikeResponseDTO)
         case deleteActionResult(Bool)
         case deleteCompletedButtonTapped
         case presentDeleteAlert
         case dismissDeleteAlert
-        case contestDetailError(Error)
         
         case delegate(DelegateAction)
 
         public enum DelegateAction {
             case backConfirmed
+            case didRequestLogout
         }
+    }
+    
+    public enum AlertAction {
+        case notAuthUserAlert
+        case presentLoginAlert
+        case dismissAlertButtonTapped
+        case dismissLoginAlert
+    }
+    
+    public enum NetworkAction {
+        case onAppearDetailContestSuccess(SearchDetailContestResponseDTO)
+        case onAppearDetailContestFailure(NetworkError)
+        case fetchLikeContest
+        case likeContestSuccess(isLike: Bool, PostLikeResponseDTO)
+        case likeContestFailure(NetworkError)
+    }
+    
+    public enum UIAction {
+        case likeButtonTapped
+        case optionButtonTapped
     }
     
     // MARK: - Body
@@ -127,19 +150,24 @@ public struct ContestDetailFeature {
                     
                     switch contestResult {
                     case .success(let responseResult):
-                        await send(.onAppearSuccess(responseResult))
+                        await send(.networkAction(.onAppearDetailContestSuccess(responseResult)))
                     case .failure(let error):
-                        await send(.contestDetailError(error))
+                        await send(.networkAction(.onAppearDetailContestFailure(error)))
                     }
                 }
                 
-            case .onAppearSuccess(let response):
+            case .networkAction(.onAppearDetailContestSuccess(let response)):
                 state.postUserId = response.authorMemberId
                 state.contestTitle = response.title
                 state.contestAuthor = response.nickname
                 state.imageUrl = response.imageUrl
                 state.isLiked = response.isLiked
                 state.likeCount = formatLikeCount(response.likeCount)
+                
+                return .none
+                
+            case .networkAction(.onAppearDetailContestFailure(let error)):
+                // TODO: - Error 처리
                 
                 return .none
                 
@@ -179,7 +207,14 @@ public struct ContestDetailFeature {
                 
                 return .none
                 
-            case .likeButtonTapped:
+            case .uiAction(.likeButtonTapped):
+                if state.authState == .skipped {
+                    return .send(.alertAction(.presentLoginAlert))
+                }
+                    
+                return .send(.networkAction(.fetchLikeContest))
+                
+            case .networkAction(.fetchLikeContest):
                 let dto = PostLikeRequestDTO(postId: state.postId, contestType: "WEEKLY")
                 
                 let isLiked = state.isLiked ?? false
@@ -189,13 +224,13 @@ public struct ContestDetailFeature {
                     
                     switch result {
                     case .success(let responseResult):
-                        await send(.likeButtonTappedSuccess(isLike: isLiked, responseResult))
+                        await send(.networkAction(.likeContestSuccess(isLike: isLiked, responseResult)))
                     case .failure(let error):
-                        await send(.contestDetailError(error))
+                        await send(.networkAction(.onAppearDetailContestFailure(error)))
                     }
                 }
             
-            case .likeButtonTappedSuccess(let isLike, let response):
+            case .networkAction(.likeContestSuccess(let isLike, let response)):
                 state.likeCount = formatLikeCount(response.likeCount)
                 state.isLiked = !isLike
                 
@@ -279,7 +314,7 @@ public struct ContestDetailFeature {
                 
                 return .none
                 
-            case .optionButtonTapped:
+            case .uiAction(.optionButtonTapped):
                 state.isContestOptionSheetPresented = true
                 
                 return .none
@@ -326,6 +361,26 @@ public struct ContestDetailFeature {
                       break
                   }
                 
+                return .none
+                
+            case .alertAction(.notAuthUserAlert):
+                state.isContestOptionSheetPresented = false
+
+                return .run { send in
+                    try await Task.sleep(nanoseconds: 100_000_000)
+                    await send(.alertAction(.presentLoginAlert))
+                }
+                
+            case .alertAction(.presentLoginAlert):
+                state.isLoginAlertPresented = true
+                return .none
+            
+            case .alertAction(.dismissAlertButtonTapped):
+                state.isLoginAlertPresented = false
+                return .send(.delegate(.didRequestLogout))
+                
+            case .alertAction(.dismissLoginAlert):
+                state.isLoginAlertPresented = false
                 return .none
                 
             default:

--- a/Soongan/Feature/DetailContestFeature/Sources/View/ContestDetailView.swift
+++ b/Soongan/Feature/DetailContestFeature/Sources/View/ContestDetailView.swift
@@ -63,7 +63,11 @@ public struct ContestDetailView: View {
                     case .delete:
                         store.send(.deleteOptionButtonTapped)
                     case .report:
-                        store.send(.reportSheetIsPresented)
+                        if store.authState == .skipped {
+                            store.send(.alertAction(.notAuthUserAlert))
+                        } else {
+                            store.send(.reportSheetIsPresented)
+                        }
                     }
                 }
             }
@@ -92,6 +96,7 @@ public struct ContestDetailView: View {
             ) {
                 ZoomableImageView(url: store.imageUrl)
             }
+            .background(alertHostingView)
             .toolbar(.hidden, for: .tabBar)
             .navigationBarBackButtonHidden(true)
             .toolbar {
@@ -156,7 +161,7 @@ public struct ContestDetailView: View {
     func bottomOptionMenuBar(isLiked: Bool, likeCount: String) -> some View {
         HStack(alignment: .top) {
             Button(action: {
-                store.send(.optionButtonTapped)
+                store.send(.uiAction(.optionButtonTapped))
             }) {
                 Image.dotOption
             }
@@ -166,7 +171,7 @@ public struct ContestDetailView: View {
             
             HStack(spacing: 0) {
                 Button(action: {
-                    store.send(.likeButtonTapped)
+                    store.send(.uiAction(.likeButtonTapped))
                 }) {
                     if isLiked {
                         Image.selectLike
@@ -186,6 +191,25 @@ public struct ContestDetailView: View {
         .padding(.bottom, 43)
         .frame(maxWidth: .infinity)
         .background(Color.white)
+    }
+    
+    @ViewBuilder
+    var alertHostingView: some View {
+        Color.clear.fullScreenCover(isPresented: $store.isLoginAlertPresented) {
+            CustomAlertView(
+                type: .showLoginView,
+                onBackgroundTap: {
+                    store.send(.alertAction(.dismissLoginAlert))
+                },
+                centerButtonAction: {
+                    store.send(.alertAction(.dismissAlertButtonTapped))
+                }
+            )
+            .presentationBackground(.clear)
+        }
+        .transaction { transaction in
+            transaction.disablesAnimations = true
+        }
     }
 }
 

--- a/Soongan/Feature/HomeFeature/Sources/Logic/HomeFeature.swift
+++ b/Soongan/Feature/HomeFeature/Sources/Logic/HomeFeature.swift
@@ -76,6 +76,7 @@ public struct HomeFeature {
         
         case showNotLoginUserAlert
         case dismissAlertButtonTapped
+        case dismissLoginAlert
         
         case homeInfoSuccess(SearchHomeInfoResponseDTO)
         
@@ -83,6 +84,7 @@ public struct HomeFeature {
                 
         public enum Delegate {
             case moveToContestTab
+            case didRequestLogout
         }
     }
     
@@ -159,6 +161,11 @@ public struct HomeFeature {
                 return .none
                 
             case .dismissAlertButtonTapped:
+                state.isAlertPresented = false
+                
+                return .send(.delegate(.didRequestLogout))
+                
+            case .dismissLoginAlert:
                 state.isAlertPresented = false
                 
                 return .none

--- a/Soongan/Feature/HomeFeature/Sources/View/HomeView.swift
+++ b/Soongan/Feature/HomeFeature/Sources/View/HomeView.swift
@@ -257,6 +257,9 @@ private extension HomeView {
         Color.clear.fullScreenCover(isPresented: $store.isAlertPresented) {
             CustomAlertView(
                 type: .showLoginView,
+                onBackgroundTap: {
+                    store.send(.dismissLoginAlert)
+                },
                 centerButtonAction: {
                     store.send(.dismissAlertButtonTapped)
                 }

--- a/Soongan/Feature/MypageFeature/Sources/Logic/MypageFeature.swift
+++ b/Soongan/Feature/MypageFeature/Sources/Logic/MypageFeature.swift
@@ -42,6 +42,7 @@ public struct MypageFeature {
         var isOptionSheetPresented: Bool = false
         var shouldNavigateToEditProfile: Bool = false
         var shouldNavigateToQuestionsList: Bool = false
+        var isLoginAlertPresented: Bool = false
         
         var userName = ""
         var userIntroduce = ""
@@ -64,6 +65,7 @@ public struct MypageFeature {
     
     // MARK: - Dependency
     
+    @Dependency(\.userDefaultsClient) var userDefaultsClient
     @Dependency(\.openURL) var openURL
     
     // MARK: - Action
@@ -74,17 +76,18 @@ public struct MypageFeature {
         case binding(BindingAction<State>)
         
         case onAppear
-        case alarmButtonTapped
-        case joinToContestButtonTapped
+        case alertAction(AlertAction)
+        case networkAction(NetworkAction)
+        case uiAction(UIAction)
+        
         case optionButtonTapped
         case optionSheetIsPresented(MyprofileOptionType)
         case profileOptionTapped(MyprofileOptionType)
         case presentSheet(SheetContentType)
         case dismissOptionSheet(Bool)
         case dismissSheet
-        
-        case myInfoSuccess(SearchMyProfileResponseDTO)
-        case myContestInfoSuccess(SearchMyContestResponseDTO)
+        case dismissLoginAlert
+        case dismissAlertButtonTapped
         
         case logoutSuccess
         case withdrawSuccess
@@ -99,7 +102,24 @@ public struct MypageFeature {
                 
         public enum Delegate {
             case moveToJoinContest
+            case didRequestLogout
         }
+    }
+    
+    public enum AlertAction {
+        case presentLoginAlert
+    }
+    
+    public enum NetworkAction {
+        case onAppearMyInfoSuccess(SearchMyProfileResponseDTO)
+        case onAppearMyContestInfoSuccess(SearchMyContestResponseDTO)
+        case onAppearMyInfoFailure(NetworkError)
+        case onAppearMyContestInfoFailure(NetworkError)
+    }
+    
+    public enum UIAction {
+        case alarmButtonTapped
+        case joinToContestButtonTapped
     }
     
     // MARK: - Body
@@ -110,6 +130,12 @@ public struct MypageFeature {
         Reduce { state, action in
             switch action {
             case .onAppear:
+                if state.authState == .skipped {
+                    state.userName = "로그인이 필요해요"
+                    state.userIntroduce = "로그인 후 본인을 소개해주세요"
+                    return .none
+                }
+
                 let dto = SearchMyContestRequestDTO(page: 0, pageSize: 50)
                 
                 return .run { send in
@@ -120,29 +146,27 @@ public struct MypageFeature {
                     
                     switch infoResult {
                     case .success(let info):
-                        await send(.myInfoSuccess(info))
+                        await send(.networkAction(.onAppearMyInfoSuccess(info)))
                     case .failure(let error):
-                        print("Profile Error: \(error.localizedDescription)")
-//                        await send(.myInfoFailure(error))
+                        await send(.networkAction(.onAppearMyInfoFailure(error)))
                     }
 
                     switch contestResult {
                     case .success(let contest):
-                        await send(.myContestInfoSuccess(contest))
+                        await send(.networkAction(.onAppearMyContestInfoSuccess(contest)))
                     case .failure(let error):
-                        print("Contest Error: \(error.localizedDescription)")
-//                        await send(.myContestFailure(error))
+                        await send(.networkAction(.onAppearMyContestInfoFailure(error)))
                     }
                 }
                 
-            case .myInfoSuccess(let response):
+            case .networkAction(.onAppearMyInfoSuccess(let response)):
                 state.userName = response.nickname ?? ""
                 state.userIntroduce = response.selfIntroduction ?? "본인을 소개시켜주세요"
                 state.userProfileImageUrl = response.profileImageUrl
                 
                 return .none
                 
-            case .myContestInfoSuccess(let response):
+            case .networkAction(.onAppearMyContestInfoSuccess(let response)):
                 state.leftContestImageList.removeAll()
                 state.rightContestImageList.removeAll()
                 
@@ -155,6 +179,16 @@ public struct MypageFeature {
                     }
                 }
 
+                return .none
+                
+            case .networkAction(.onAppearMyInfoFailure):
+                state.userName = "정보 없음"
+                state.userIntroduce = "본인을 소개시켜주세요"
+                return .none
+                
+            case .networkAction(.onAppearMyContestInfoFailure):
+                state.leftContestImageList.removeAll()
+                state.rightContestImageList.removeAll()
                 return .none
                 
             case let .path(.element(id: _, action: action)):
@@ -174,7 +208,7 @@ public struct MypageFeature {
             case .binding(_):
                 return .none
                 
-            case .alarmButtonTapped:
+            case .uiAction(.alarmButtonTapped):
                 state.path.append(.alarmList(AlarmListFeature.State()))
                 return .none
                 
@@ -187,8 +221,20 @@ public struct MypageFeature {
                 
                 switch tappedOption {
                 case .editMyProfile:
-                    state.shouldNavigateToEditProfile = true
-
+                    switch state.authState {
+                    case .skipped:
+                        state.activeSheet = nil
+                        return .run { send in
+                            try await Task.sleep(nanoseconds: 100_000_000)
+                            await send(.alertAction(.presentLoginAlert))
+                        }
+                        
+                    case .loggedIn:
+                        state.shouldNavigateToEditProfile = true
+                    default:
+                        break
+                    }
+                    
                 case .pushAlarmSetting:
                     state.activeSheet = .alarmSetting
                     
@@ -205,10 +251,34 @@ public struct MypageFeature {
                     state.shouldNavigateToQuestionsList = true
                     
                 case .withdraw:
-                    state.activeSheet = .withdraw
+                    switch state.authState {
+                    case .skipped:
+                        state.activeSheet = nil
+                        return .run { send in
+                            try await Task.sleep(nanoseconds: 100_000_000)
+                            await send(.alertAction(.presentLoginAlert))
+                        }
+
+                    case .loggedIn:
+                        state.activeSheet = .withdraw
+                    default:
+                        break
+                    }
                     
                 case .logout:
-                    state.activeSheet = .logout
+                    switch state.authState {
+                    case .skipped:
+                        state.activeSheet = nil
+                        return .run { send in
+                            try await Task.sleep(nanoseconds: 100_000_000)
+                            await send(.alertAction(.presentLoginAlert))
+                        }
+                        
+                    case .loggedIn:
+                        state.activeSheet = .logout
+                    default:
+                        break
+                    }
                 }
                 
                 return .none
@@ -260,17 +330,41 @@ public struct MypageFeature {
                 return .none
                 
             case .deleteMyInfomation:
-                state.$authState.withLock { $0 = .loggedOut }
+                // 1. Keychain에 저장된 모든 토큰 삭제
                 KeychainManager.shared.clearTokens()
                 
-                return .none
+                // 2. UserDefaults에 저장된 모든 관련 정보 삭제
+                return .run { [userDefaultsClient] send in
+                    // User 관련 정보 삭제
+                    await userDefaultsClient.remove(UserDefaultKeys.User.username.rawValue)
+                    await userDefaultsClient.remove(UserDefaultKeys.User.userID.rawValue)
+                    
+                    // Settings 관련 정보 삭제
+                    await userDefaultsClient.remove(UserDefaultKeys.Settings.isNotificationEnabled.rawValue)
+                    
+                    // 3. 모든 정보 삭제 후, 로그아웃 신호를 부모에게 전달
+                    await send(.delegate(.didRequestLogout))
+                }
                 
             case .contestDetailImageTapped(let postId):
                 state.path.append(.contestDetail(ContestDetailFeature.State(postId: postId)))
                 return .none
                 
-            case .joinToContestButtonTapped:
+            case .uiAction(.joinToContestButtonTapped):
+                if state.authState == .skipped {
+                    state.isLoginAlertPresented = true
+                    return .none
+                }
+                
                 return .send(.delegate(.moveToJoinContest))
+                
+            case .dismissLoginAlert:
+                state.isLoginAlertPresented = false
+                return .none
+                
+            case .dismissAlertButtonTapped:
+                state.isLoginAlertPresented = false
+                return .send(.delegate(.didRequestLogout))
                 
             case .dismissOptionSheet(_):
                 state.isOptionSheetPresented = false
@@ -293,6 +387,10 @@ public struct MypageFeature {
                 
             case .dismissSheet:
                 state.activeSheet = nil
+                return .none
+            
+            case .alertAction(.presentLoginAlert):
+                state.isLoginAlertPresented = true
                 return .none
                 
             default:

--- a/Soongan/Feature/MypageFeature/Sources/View/MypageView.swift
+++ b/Soongan/Feature/MypageFeature/Sources/View/MypageView.swift
@@ -70,6 +70,10 @@ public struct MypageView: View {
             .frame(maxHeight: .infinity)
             .toolbar(.hidden, for: .tabBar)
             .background(DesignSystem.Color.soonganBG)
+            .background(alertHostingView)
+            .onAppear {
+                store.send(.onAppear)
+            }
             .sheet(
                 isPresented: $store.isOptionSheetPresented.sending(\.dismissOptionSheet)
             ) {
@@ -87,9 +91,6 @@ public struct MypageView: View {
                     store.successSheet = nil
                     store.send(.deleteMyInfomation)
                 }
-            }
-            .onAppear {
-                store.send(.onAppear)
             }
         } destination: { store in
             switch store.case {
@@ -112,7 +113,7 @@ private extension MypageView {
     func rightButtonsSection() -> some View {
         HStack(spacing: 28) {
             Button(action: {
-                store.send(.alarmButtonTapped)
+                store.send(.uiAction(.alarmButtonTapped))
             }){
                 Image.alarmIcon
                     .resizable()
@@ -140,7 +141,7 @@ private extension MypageView {
                 .padding(.bottom, 12)
             
             Button(action: {
-                store.send(.joinToContestButtonTapped)
+                store.send(.uiAction(.joinToContestButtonTapped))
             }) {
                 VStack(spacing: 4) {
                     Text("참가하러 가기")
@@ -155,6 +156,25 @@ private extension MypageView {
             Spacer(minLength: 370)
         }
         .foregroundStyle(Color.black100)
+    }
+    
+    @ViewBuilder
+    var alertHostingView: some View {
+        Color.clear.fullScreenCover(isPresented: $store.isLoginAlertPresented) {
+            CustomAlertView(
+                type: .showLoginView,
+                onBackgroundTap: {
+                    store.send(.dismissLoginAlert)
+                },
+                centerButtonAction: {
+                    store.send(.dismissAlertButtonTapped)
+                }
+            )
+            .presentationBackground(.clear)
+        }
+        .transaction { transaction in
+            transaction.disablesAnimations = true
+        }
     }
 }
 

--- a/Soongan/Soongan/Sources/AppFeature.swift
+++ b/Soongan/Soongan/Sources/AppFeature.swift
@@ -19,8 +19,20 @@ public struct AppFeature {
     @ObservableState
     public struct State: Equatable {
         @Shared(.appStorage("AuthState")) var authState: AuthType = .loggedOut
-        var login: LoginFeature.State = LoginFeature.State()
-        var mainTab: MainTabFeature.State = MainTabFeature.State()
+        
+        var login: LoginFeature.State?
+        var mainTab: MainTabFeature.State?
+        
+        public init() {
+            // 앱 시작 시 authState에 따라 초기 상태를 설정
+            if authState == .loggedOut {
+                self.login = LoginFeature.State()
+                self.mainTab = nil
+            } else {
+                self.login = nil
+                self.mainTab = MainTabFeature.State(selectedTab: .home)
+            }
+        }
     }
     
     public enum Action {
@@ -29,33 +41,39 @@ public struct AppFeature {
     }
     
     public var body: some ReducerOf<Self> {
-        Scope(state: \.login, action: \.login) {
-            LoginFeature()
-        }
-        
-        Scope(state: \.mainTab, action: \.mainTab) {
-            MainTabFeature()
-        }
-        
         Reduce { state, action in
             switch action {
-            case .login(.delegate(.loginSuccess)):
-                
-                print("AppFeature 로 데이터 옴")
-                state.$authState.withLock { $0 = .loggedIn }
+            case .login(.delegate(let delegateAction)):
+                switch delegateAction {
+                case .loginSuccess:
+                    state.$authState.withLock { $0 = .loggedIn }
+                    state.mainTab = MainTabFeature.State(selectedTab: .home)
+                    state.login = nil
+                    
+                case .skippAuth:
+                    state.$authState.withLock { $0 = .skipped }
+                    state.mainTab = MainTabFeature.State(selectedTab: .home)
+                    state.login = nil
+                }
                 
                 return .none
                 
-            case .login(.delegate(.skippAuth)):
-                state.$authState.withLock { $0 = .skipped }
-                return .none
-            
-            case .mainTab:
+            case .mainTab(.delegate(.logoutCompleted)):
+                state.$authState.withLock { $0 = .loggedOut }
+                state.login = LoginFeature.State()
+                state.mainTab = nil
+                
                 return .none
                 
             default:
                 return .none
             }
+        }
+        .ifLet(\.login, action: \.login) {
+            LoginFeature()
+        }
+        .ifLet(\.mainTab, action: \.mainTab) {
+            MainTabFeature()
         }
     }
 }

--- a/Soongan/Soongan/Sources/AppView.swift
+++ b/Soongan/Soongan/Sources/AppView.swift
@@ -16,13 +16,22 @@ public struct AppView: View {
     @Bindable var store: StoreOf<AppFeature>
     
     public var body: some View {
-        
         switch store.authState {
         case .loggedIn, .skipped:
-            MainTabView(store: store.scope(state: \.mainTab, action: \.mainTab))
+            // mainTab 상태가 nil이 아닐 때만 MainTabView를 렌더링
+            IfLetStore(
+                self.store.scope(state: \.mainTab, action: \.mainTab)
+            ) { mainTabStore in
+                MainTabView(store: mainTabStore)
+            }
             
         case .loggedOut:
-            LoginView(store: store.scope(state: \.login, action: \.login))
+            // login 상태가 nil이 아닐 때만 LoginView를 렌더링
+            IfLetStore(
+                self.store.scope(state: \.login, action: \.login)
+            ) { loginStore in
+                LoginView(store: loginStore)
+            }
         }
     }
 }

--- a/Soongan/Soongan/Sources/MainTabFeature.swift
+++ b/Soongan/Soongan/Sources/MainTabFeature.swift
@@ -23,7 +23,7 @@ public struct MainTabFeature {
     
     @ObservableState
     public struct State: Equatable {
-        var selectedTab: Tab = .home
+        var selectedTab: Tab// = .home
         var home: HomeFeature.State = .init(weekTopic: "평화", startPeriod: "2024.05.10 09:00:00", endPeriod: "2024.05.16 23:59:59")
         var contest: ContestFeature.State = .init()
         var allTimeContest: AllTimeContestFeature.State = .init()
@@ -59,6 +59,12 @@ public struct MainTabFeature {
         case contest(ContestFeature.Action)
         case allTimeContest(AllTimeContestFeature.Action)
         case mypage(MypageFeature.Action)
+        
+        case delegate(Delegate)
+                
+        public enum Delegate {
+            case logoutCompleted
+        }
     }
     
     // MARK: - Body
@@ -91,18 +97,30 @@ public struct MainTabFeature {
                 case .delegate(.moveToContestTab):
                     state.selectedTab = .contest
                     return .none
+                    
+                case .delegate(.didRequestLogout):
+                    return .send(.delegate(.logoutCompleted))
+                    
                 default:
                     return .none
                 }
                 
-            case .contest:
-                return .none
+            case .contest(let contestAction):
+                switch contestAction {
+                case .delegate(.logoutRequested):
+                    return .send(.delegate(.logoutCompleted))
+                default:
+                    return .none
+                }
                 
             case .allTimeContest(let allTimeAction):
                 switch allTimeAction {
                 case .delegate(.moveToContestTab):
                     state.selectedTab = .contest
                     return .none
+                    
+                case .delegate(.logoutRequested):
+                    return .send(.delegate(.logoutCompleted))
                     
                 default:
                     return .none
@@ -114,9 +132,15 @@ public struct MainTabFeature {
                     state.selectedTab = .home
                     return .none
                     
+                case .delegate(.didRequestLogout):
+                    return .send(.delegate(.logoutCompleted))
+                    
                 default:
                     return .none
                 }
+                
+            case .delegate:
+                return .none
             }
         }
     }

--- a/Soongan/Soongan/Sources/MainTabView.swift
+++ b/Soongan/Soongan/Sources/MainTabView.swift
@@ -106,7 +106,7 @@ public struct MainTabView: View {
 
 #Preview {
     MainTabView(store:
-        Store(initialState: MainTabFeature.State()) {
+            Store(initialState: MainTabFeature.State(selectedTab: .home)) {
             MainTabFeature()
         }
     )


### PR DESCRIPTION
## 📟 관련 이슈
- Resolved: #25 

<br>

## 👷 작업한 내용
<!-- 작업한 내용을 적어주세요. -->
- 앱의 핵심 상태 관리 구조를 리팩토링하여, 로그아웃 시 메모리가 정상적으로 해제되도록 수정
- 로그아웃 및 회원탈퇴 시 `Keychain` 과 함께 `UserDefaults` 의 사용자 데이터를 모두 삭제하도록 초기화 로직 추가
- 상세 화면 등 앱의 어느 위치에서든 안전하게 로그아웃이 처리되도록 `Delegate` 전달 로직 구현
- 마이페이지 진입 시, '둘러보기' 상태에서는 불필요한 API 호출을 하지 않도록 로직 수정
- `CustomAlertView` 의 배경을 탭하여 닫을 수 있는 기능을 추가하여 사용자 편의성 개선

<br>

## 📸 스크린샷
|예시|홈화면(작품 등록시)|콘테스트 피드(신고하기 시)|
|:--:|:--:|:--:|
|Img|<img src = "https://github.com/user-attachments/assets/b5c7d1b1-a983-43df-bce0-640712391476" width ="250">|<img src = "https://github.com/user-attachments/assets/23229aa7-c08e-4caf-8041-0d0c1c1ee737" width ="250">|

<br>

## 🚨 참고 사항
<!-- 참고 사항을 적어주세요. 없으면 지워주세요. -->

### 1. 앱 전역 상태 관리 구조 리팩토링
   - **옵셔널 상태 도입**: `AppFeature` 가 관리하던 `LoginFeature` 와 `MainTabFeature`의 상태를 옵셔널(?)로 변경했습니다.
   - **메모리 누수 해결**: 로그아웃 또는 둘러보기 종료 시, 관련 피처(`MainTabFeature` 등)의 상태가 메모리에서 완전히 해제(nil)되도록 수정했습니다. 이제 다시 로그인하거나 둘러보기를 시작할 때 항상 깨끗한 초기 상태로 진입하여 이전 데이터가 남는 문제를 해결했습니다.
   - **데이터 초기화 로직 강화**: 로그아웃 및 회원탈퇴 시, `Keychain` 뿐만 아니라 `UserDefaults` 에 저장된 모든 사용자 관련 데이터(닉네임, ID 등)를 함께 삭제하여 개인정보를 안전하게 초기화하도록 개선했습니다.

<br>

### 2. Alert 배경 터치 시에 대한 액션 추가
   - `CustomAlertView` 개선: `fullScreenCover` 로 띄워진 `CustomAlertView` 의 어두운 배경을 탭하면 알림창이 닫히는 기능을 추가하여 사용자 편의성을 개선했습니다.

<br>

### 3. 둘러보기(skipped) 상태 로직 개선
   - **불필요한 API 호출 방지**: 마이페이지 진입 시, 둘러보기 상태(`.skipped`)에서는 사용자 정보를 불러오는 불필요한 네트워크 요청을 보내지 않도록 수정했습니다.
   - **로그인 유도**: 둘러보기 상태에서 프로필 수정, 로그아웃 등 로그인이 필요한 기능을 시도할 경우, 로그인 화면으로 이동시키는 대신 "로그인이 필요하다"는 알림창을 먼저 띄우도록 로직을 수정했습니다.

<br>

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
