### PR TITLE
[Feat] #33 - 스플래시 화면 및 앱 업데이트 확인 기능 구현

### DIFF
--- a/Soongan/AppDependencies/Sources/AppVersionClient.swift
+++ b/Soongan/AppDependencies/Sources/AppVersionClient.swift
@@ -11,7 +11,7 @@ import Dependencies
 // MARK: - AppVersionClient
 
 public struct AppVersionClient {
-    public var getCurrentVersion: () -> String
+    public var getCurrentVersion: () -> String?
 }
 
 // MARK: - Dependency (Live)
@@ -20,7 +20,7 @@ extension AppVersionClient: DependencyKey {
     public static let liveValue = Self(
         getCurrentVersion: {
             guard let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String else {
-                return "버전 정보 없음"
+                return nil
             }
             return version
         }

--- a/Soongan/AppDependencies/Sources/AppVersionClient.swift
+++ b/Soongan/AppDependencies/Sources/AppVersionClient.swift
@@ -1,0 +1,35 @@
+//
+//  AppVersionClient.swift
+//  AppDependencies
+//
+//  Created by ParkJunHyuk on 8/24/25.
+//
+
+import Foundation
+import Dependencies
+
+// MARK: - AppVersionClient
+
+public struct AppVersionClient {
+    public var getCurrentVersion: () -> String
+}
+
+// MARK: - Dependency (Live)
+
+extension AppVersionClient: DependencyKey {
+    public static let liveValue = Self(
+        getCurrentVersion: {
+            guard let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String else {
+                return "버전 정보 없음"
+            }
+            return version
+        }
+    )
+}
+
+extension DependencyValues {
+    public var appVersionClient: AppVersionClient {
+        get { self[AppVersionClient.self] }
+        set { self[AppVersionClient.self] = newValue }
+    }
+}

--- a/Soongan/AppDependencies/Sources/NotificationClient.swift
+++ b/Soongan/AppDependencies/Sources/NotificationClient.swift
@@ -23,12 +23,14 @@ extension NotificationClient: DependencyKey {
             let authOptions: UNAuthorizationOptions = [.alert, .badge, .sound]
             do {
                 let granted = try await UNUserNotificationCenter.current().requestAuthorization(options: authOptions)
-                DispatchQueue.main.async {
-                    UIApplication.shared.registerForRemoteNotifications()
+                if granted {
+                    DispatchQueue.main.async {
+                        UIApplication.shared.registerForRemoteNotifications()
+                    }
                 }
                 return granted
             } catch {
-                // 실제로는 에러 처리를 하는 것이 좋습니다.
+                print("Failed to request notification authorization: \(error.localizedDescription)")
                 return false
             }
         }

--- a/Soongan/AppDependencies/Sources/NotificationClient.swift
+++ b/Soongan/AppDependencies/Sources/NotificationClient.swift
@@ -1,0 +1,43 @@
+//
+//  NotificationClient.swift
+//  AppDependencies
+//
+//  Created by ParkJunHyuk on 8/24/25.
+//
+
+import UIKit
+import UserNotifications
+import Dependencies
+
+// MARK: - NotificationClient
+
+public struct NotificationClient {
+    public var requestAuthorization: @Sendable () async -> Bool
+}
+
+// MARK: - Dependency (Live)
+
+extension NotificationClient: DependencyKey {
+    public static let liveValue = Self(
+        requestAuthorization: {
+            let authOptions: UNAuthorizationOptions = [.alert, .badge, .sound]
+            do {
+                let granted = try await UNUserNotificationCenter.current().requestAuthorization(options: authOptions)
+                DispatchQueue.main.async {
+                    UIApplication.shared.registerForRemoteNotifications()
+                }
+                return granted
+            } catch {
+                // 실제로는 에러 처리를 하는 것이 좋습니다.
+                return false
+            }
+        }
+    )
+}
+
+extension DependencyValues {
+    public var notificationClient: NotificationClient {
+        get { self[NotificationClient.self] }
+        set { self[NotificationClient.self] = newValue }
+    }
+}

--- a/Soongan/DesignSystem/Sources/Component/CustomAlertView.swift
+++ b/Soongan/DesignSystem/Sources/Component/CustomAlertView.swift
@@ -151,6 +151,8 @@ public enum AlertType: Identifiable {
     
     var centerButtonTitle: String {
         switch self {
+        case .showLoginView:
+            return "로그인하기"
         case .forceUpdate:
             return "업데이트 하러가기"
         default:

--- a/Soongan/DesignSystem/Sources/Component/CustomAlertView.swift
+++ b/Soongan/DesignSystem/Sources/Component/CustomAlertView.swift
@@ -71,7 +71,7 @@ public struct CustomAlertView: View {
                 Button(action: {
                     centerButtonAction?()
                 }) {
-                    Text(type == .showLoginView ? "로그인하기" : "확인")
+                    Text(type.centerButtonTitle)
                         .font(DesignSystem.Font.semibold14)
                         .foregroundStyle(Color.black100)
                         .frame(height: 40)
@@ -126,6 +126,7 @@ public enum AlertType: Identifiable {
     case showLoginView
     case deletePost
     case deletePostComplete
+    case forceUpdate
     
     public var id: Self {
         self
@@ -143,6 +144,18 @@ public enum AlertType: Identifiable {
             return "정말 작품을\n삭제하시겠습니까?"
         case .deletePostComplete:
             return "삭제가 완료되었습니다"
+        case .forceUpdate:
+            return "원활한 앱 활동을 위해\n버전 업데이트가 필요합니다."
+        }
+    }
+    
+    var centerButtonTitle: String {
+        switch self {
+        case .forceUpdate:
+            return "업데이트 하러가기"
+        default:
+            return "확인"
+        
         }
     }
 }

--- a/Soongan/Feature/AllTimeContestFeature/Project.swift
+++ b/Soongan/Feature/AllTimeContestFeature/Project.swift
@@ -2,12 +2,6 @@ import ProjectDescription
 
 let project = Project(
     name: "AllTimeContestFeature",
-    packages: [
-      .package(
-        url: "https://github.com/pointfreeco/swift-composable-architecture.git",
-        from: "1.17.0"
-      ),
-    ],
     targets: [
         .target(
             name: "AllTimeContestFeature",

--- a/Soongan/Feature/AuthFeature/Sources/Logic/LoginFeature.swift
+++ b/Soongan/Feature/AuthFeature/Sources/Logic/LoginFeature.swift
@@ -52,6 +52,7 @@ public struct LoginFeature {
     @Dependency(\.appleLoginService) var appleLoginService
     @Dependency(\.kakaoLoginService) var kakaoLoginService
     @Dependency(\.userDefaultsClient) var userDefaultsClient
+    @Dependency(\.notificationClient) var notificationClient
     @Dependency(\.openURL) var openURL
     
     // MARK: - Action
@@ -60,6 +61,7 @@ public struct LoginFeature {
         case path(StackActionOf<LoginPath>)
         
         case binding(BindingAction<State>)
+        case onAppear
         case kakaoButtonTapped
         case appleButtonTapped
         
@@ -81,8 +83,6 @@ public struct LoginFeature {
             case loginSuccess
             case skippAuth
         }
-        
-//        case successSignup(SignupFeature.Action)
     }
     
     // MARK: - Body
@@ -90,6 +90,11 @@ public struct LoginFeature {
     public var body: some ReducerOf<Self> {
         Reduce { state, action in
             switch action {
+            case .onAppear:
+                return .run { _ in
+                    let _  = await self.notificationClient.requestAuthorization()
+                }
+                
             case .binding(_):
                 return .none
                 

--- a/Soongan/Feature/AuthFeature/Sources/View/LoginView.swift
+++ b/Soongan/Feature/AuthFeature/Sources/View/LoginView.swift
@@ -103,6 +103,9 @@ public struct LoginView: View {
                     }
                 }
             }
+            .onAppear {
+                store.send(.onAppear)
+            }
         } destination: { store in
             switch store.case {
             case .signup(let store):

--- a/Soongan/Feature/ContestFeature/Project.swift
+++ b/Soongan/Feature/ContestFeature/Project.swift
@@ -2,12 +2,6 @@ import ProjectDescription
 
 let project = Project(
     name: "ContestFeature",
-    packages: [
-      .package(
-        url: "https://github.com/pointfreeco/swift-composable-architecture.git",
-        from: "1.17.0"
-      ),
-    ],
     targets: [
         .target(
             name: "ContestFeature",

--- a/Soongan/Feature/DetailContestFeature/Project.swift
+++ b/Soongan/Feature/DetailContestFeature/Project.swift
@@ -2,12 +2,6 @@ import ProjectDescription
 
 let project = Project(
     name: "DetailContestFeature",
-    packages: [
-      .package(
-        url: "https://github.com/pointfreeco/swift-composable-architecture.git",
-        from: "1.17.0"
-      ),
-    ],
     targets: [
         .target(
             name: "DetailContestFeature",

--- a/Soongan/Feature/HomeFeature/Project.swift
+++ b/Soongan/Feature/HomeFeature/Project.swift
@@ -2,12 +2,6 @@ import ProjectDescription
 
 let project = Project(
     name: "HomeFeature",
-    packages: [
-      .package(
-        url: "https://github.com/pointfreeco/swift-composable-architecture.git",
-        from: "1.17.0"
-      ),
-    ],
     targets: [
         .target(
             name: "HomeFeature",

--- a/Soongan/Feature/HomeFeature/Sources/View/HomeView.swift
+++ b/Soongan/Feature/HomeFeature/Sources/View/HomeView.swift
@@ -283,7 +283,7 @@ private extension HomeView {
     }
     
     func periodSection(startPeriod: String, endPeriod: String) -> some View {
-        VStack(spacing: 8) {
+        VStack(alignment: .leading, spacing: 8) {
             HStack(spacing: 4) {
                 Text("시작일")
                 
@@ -291,7 +291,6 @@ private extension HomeView {
                     
                 Text(startPeriod)
             }
-            .font(DesignSystem.Font.medium14)
             
             HStack(spacing: 4) {
                 Text("마감일")
@@ -300,9 +299,9 @@ private extension HomeView {
                     
                 Text(endPeriod)
             }
-            .font(DesignSystem.Font.medium14)
-            .foregroundStyle(DesignSystem.Color.black100)
         }
+        .font(DesignSystem.Font.medium14)
+        .foregroundStyle(DesignSystem.Color.black100)
     }
     
     @ViewBuilder

--- a/Soongan/Feature/MypageFeature/Project.swift
+++ b/Soongan/Feature/MypageFeature/Project.swift
@@ -2,12 +2,6 @@ import ProjectDescription
 
 let project = Project(
     name: "MypageFeature",
-    packages: [
-      .package(
-        url: "https://github.com/pointfreeco/swift-composable-architecture.git",
-        from: "1.17.0"
-      ),
-    ],
     targets: [
         .target(
             name: "MypageFeature",

--- a/Soongan/Feature/SplashFeature/Project.swift
+++ b/Soongan/Feature/SplashFeature/Project.swift
@@ -1,13 +1,13 @@
 import ProjectDescription
 
 let project = Project(
-    name: "AuthFeature",
+    name: "SplashFeature",
     targets: [
         .target(
-            name: "AuthFeature",
+            name: "SplashFeature",
             destinations: .iOS,
             product: .staticFramework,
-            bundleId: "com.captures.AuthFeature.Soongan",
+            bundleId: "com.captures.SplashFeature.Soongan",
             deploymentTargets: .iOS("18.0"),
             infoPlist: .default,
             sources: ["Sources/**"],
@@ -15,8 +15,6 @@ let project = Project(
             dependencies: [
                 .external(name: "ComposableArchitecture"),
                 .project(target: "DesignSystem", path: "../../DesignSystem"),
-                .project(target: "CoreKakaoLogin", path: "../../Core/CoreKakaoLogin"),
-                .project(target: "CoreAppleLogin", path: "../../Core/CoreAppleLogin"),
                 .project(target: "CoreNetwork", path: "../../Core/CoreNetwork"),
                 .project(target: "AppDependencies", path: "../../AppDependencies")
             ]

--- a/Soongan/Feature/SplashFeature/Sources/Logic/SplashFeature.swift
+++ b/Soongan/Feature/SplashFeature/Sources/Logic/SplashFeature.swift
@@ -42,7 +42,7 @@ public struct SplashFeature {
         case binding(BindingAction<State>)
         case onAppear
         case delayCompleted
-        case appVersionResponse(String)
+        case appVersionResponse(String?)
         
         case fetchRequiredVersion
         case requiredVersionResponse(Result<String, Error>)

--- a/Soongan/Feature/SplashFeature/Sources/Logic/SplashFeature.swift
+++ b/Soongan/Feature/SplashFeature/Sources/Logic/SplashFeature.swift
@@ -1,0 +1,118 @@
+//
+//  SplashFeature.swift
+//  SplashFeature
+//
+//  Created by ParkJunHyuk on 8/24/25.
+//
+
+//import SwiftUI
+
+import AppDependencies
+import CoreNetwork
+import DesignSystem
+import Shared
+
+import ComposableArchitecture
+
+@Reducer
+public struct SplashFeature {
+    
+    // MARK: - State
+    
+    @ObservableState
+    public struct State: Equatable {
+        var currentVersion: String?
+        var isUpdateAlertPresented: Bool = false
+        
+        public init() {}
+    }
+    
+    // MARK: - Init
+
+    public init() {}
+    
+    // MARK: - Dependency
+    
+    @Dependency(\.appVersionClient) var appVersionClient
+    @Dependency(\.continuousClock) var clock
+    
+    // MARK: - Action
+
+    public enum Action: BindableAction {
+        case binding(BindingAction<State>)
+        case onAppear
+        case delayCompleted
+        case appVersionResponse(String)
+        
+        case fetchRequiredVersion
+        case requiredVersionResponse(Result<String, Error>)
+        case setUpdateAlert(isPresented: Bool)
+        case updateButtonTapped
+        
+        case delegate(Delegate)
+        
+        public enum Delegate {
+            case versionCheckCompleted
+        }
+    }
+    
+    // MARK: - Body
+    
+    public var body: some ReducerOf<Self> {
+        BindingReducer()
+        
+        Reduce { state, action in
+            switch action {
+            case .onAppear:
+                return .run { send in
+                    try await self.clock.sleep(for: .seconds(1.5))
+                    await send(.delayCompleted)
+                }
+
+            case .delayCompleted:
+                return .run { send in
+                    let version = self.appVersionClient.getCurrentVersion()
+                    await send(.appVersionResponse(version))
+                    await send(.fetchRequiredVersion)
+                }
+                
+            case .appVersionResponse(let version):
+                state.currentVersion = version
+                return .none
+                
+            case .fetchRequiredVersion:
+                return .run { send in
+                    // TODO: 서버에서 최소 버전 가져오는 API 호출
+                    await send(.requiredVersionResponse(.success("0.1.0")))
+                }
+                
+            case .requiredVersionResponse(.success(let requiredVersion)):
+                if let currentVersion = state.currentVersion, currentVersion.compare(requiredVersion, options: .numeric) == .orderedAscending {
+                    state.isUpdateAlertPresented = true
+                } else {
+                    return .send(.delegate(.versionCheckCompleted))
+                }
+                return .none
+                
+            case .requiredVersionResponse(.failure):
+                return .send(.delegate(.versionCheckCompleted))
+                
+            case .setUpdateAlert(let isPresented):
+                state.isUpdateAlertPresented = isPresented
+                return .none
+                
+            case .updateButtonTapped:
+                print("앱 스토어로 이동")
+                // TODO: App Store URL 열기
+                state.isUpdateAlertPresented = false
+                return .none
+                
+            case .binding:
+                return .none
+                
+            case .delegate(_):
+                return .none
+            }
+        }
+    }
+}

--- a/Soongan/Feature/SplashFeature/Sources/View/SplashView.swift
+++ b/Soongan/Feature/SplashFeature/Sources/View/SplashView.swift
@@ -1,0 +1,79 @@
+//
+//  SplashView.swift
+//  SplashFeature
+//
+//  Created by ParkJunHyuk on 8/23/25.
+//
+
+import SwiftUI
+
+import DesignSystem
+
+import ComposableArchitecture
+
+public struct SplashView: View {
+    
+    @Bindable var store: StoreOf<SplashFeature>
+    
+    // MARK: - Init
+    
+    public init(
+        store: StoreOf<SplashFeature>
+    ) {
+        self.store = store
+    }
+    
+    // MARK: - Body
+    
+    public var body: some View {
+        GeometryReader { geometry in
+            VStack {
+                ZStack(alignment: .topTrailing) {
+                    HStack(alignment: .top, spacing: 0) {
+                        Text("순")
+                            .padding(.bottom, 58)
+                        
+                        Text("간")
+                            .padding(.top, 58)
+                            .padding(.leading, -9)
+                    }
+                    .font(DesignSystem.Font.title80, lineHeight: 112)
+                    
+                    Image.soonganLogo
+                        .padding(.top, 18)
+                        .padding(.trailing, 12)
+                }
+                .padding(.top, geometry.size.height * 0.251) // 214 / 852 ≈ 0.251
+                
+                Spacer()
+                    .frame(height: geometry.size.height * 0.548) // 467 / 852 ≈ 0.548
+            }
+            .frame(maxWidth: .infinity) 
+        }
+        .onAppear {
+            store.send(.onAppear)
+        }
+        .fullScreenCover(isPresented: $store.isUpdateAlertPresented) {
+            CustomAlertView(
+                type: .forceUpdate,
+                centerButtonAction: {
+                    store.send(.updateButtonTapped)
+                }
+            )
+            .presentationBackground(.clear)
+        }
+        .transaction { transaction in
+            transaction.disablesAnimations = true
+        }
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    SplashView(
+        store: Store(initialState: SplashFeature.State()) {
+            SplashFeature()
+        }
+    )
+}

--- a/Soongan/Feature/UserProfileFeature/Project.swift
+++ b/Soongan/Feature/UserProfileFeature/Project.swift
@@ -2,12 +2,6 @@ import ProjectDescription
 
 let project = Project(
     name: "UserProfileFeature",
-    packages: [
-      .package(
-        url: "https://github.com/pointfreeco/swift-composable-architecture.git",
-        from: "1.17.0"
-      ),
-    ],
     targets: [
         .target(
             name: "UserProfileFeature",

--- a/Soongan/Project.swift
+++ b/Soongan/Project.swift
@@ -64,6 +64,7 @@ let project = Project(
                 .project(target: "Shared", path: "Shared"),
                 .project(target: "DesignSystem", path: "DesignSystem"),
                 .project(target: "AuthFeature", path: "Feature/AuthFeature"),
+                .project(target: "SplashFeature", path: "Feature/SplashFeature"),
                 .project(target: "HomeFeature", path: "Feature/HomeFeature"),
                 .project(target: "ContestFeature", path: "Feature/ContestFeature"),
                 .project(target: "AllTimeContestFeature", path: "Feature/AllTimeContestFeature"),

--- a/Soongan/Soongan/Sources/AppFeature.swift
+++ b/Soongan/Soongan/Sources/AppFeature.swift
@@ -11,38 +11,49 @@ import SwiftUI
 import ComposableArchitecture
 
 import AuthFeature
+import SplashFeature
 import Shared
 
 @Reducer
 public struct AppFeature {
     
+    // MARK: - State
+    
     @ObservableState
     public struct State: Equatable {
         @Shared(.appStorage("AuthState")) var authState: AuthType = .loggedOut
         
+        var splash: SplashFeature.State?
         var login: LoginFeature.State?
         var mainTab: MainTabFeature.State?
         
-        public init() {
-            // 앱 시작 시 authState에 따라 초기 상태를 설정
-            if authState == .loggedOut {
-                self.login = LoginFeature.State()
-                self.mainTab = nil
-            } else {
-                self.login = nil
-                self.mainTab = MainTabFeature.State(selectedTab: .home)
-            }
+        public init()  {
+            self.splash = SplashFeature.State()
         }
     }
     
+    // MARK: - Action
+    
     public enum Action {
+        case splash(SplashFeature.Action)
         case login(LoginFeature.Action)
         case mainTab(MainTabFeature.Action)
     }
     
+    // MARK: - Body
+    
     public var body: some ReducerOf<Self> {
         Reduce { state, action in
             switch action {
+            case .splash(.delegate(.versionCheckCompleted)):
+                state.splash = nil
+                if state.authState == .loggedOut {
+                    state.login = LoginFeature.State()
+                } else {
+                    state.mainTab = MainTabFeature.State(selectedTab: .home)
+                }
+                return .none
+                
             case .login(.delegate(let delegateAction)):
                 switch delegateAction {
                 case .loginSuccess:
@@ -68,6 +79,9 @@ public struct AppFeature {
             default:
                 return .none
             }
+        }
+        .ifLet(\.splash, action: \.splash) {
+            SplashFeature()
         }
         .ifLet(\.login, action: \.login) {
             LoginFeature()

--- a/Soongan/Soongan/Sources/AppView.swift
+++ b/Soongan/Soongan/Sources/AppView.swift
@@ -10,29 +10,40 @@ import SwiftUI
 
 import ComposableArchitecture
 import AuthFeature
+import SplashFeature
 
 public struct AppView: View {
     
     @Bindable var store: StoreOf<AppFeature>
     
+    // MARK: - Body
+    
     public var body: some View {
-        switch store.authState {
-        case .loggedIn, .skipped:
-            // mainTab 상태가 nil이 아닐 때만 MainTabView를 렌더링
-            IfLetStore(
-                self.store.scope(state: \.mainTab, action: \.mainTab)
-            ) { mainTabStore in
-                MainTabView(store: mainTabStore)
-            }
-            
-        case .loggedOut:
-            // login 상태가 nil이 아닐 때만 LoginView를 렌더링
-            IfLetStore(
-                self.store.scope(state: \.login, action: \.login)
-            ) { loginStore in
-                LoginView(store: loginStore)
+        ZStack {
+            if let store = store.scope(state: \.splash, action: \.splash) {
+                SplashView(store: store)
+                    .transition(.opacity)
+            } else {
+                switch store.authState {
+                case .loggedIn, .skipped:
+                    // mainTab 상태가 nil이 아닐 때만 MainTabView를 렌더링
+                    IfLetStore(
+                        self.store.scope(state: \.mainTab, action: \.mainTab)
+                    ) { mainTabStore in
+                        MainTabView(store: mainTabStore)
+                    }
+                    
+                case .loggedOut:
+                    // login 상태가 nil이 아닐 때만 LoginView를 렌더링
+                    IfLetStore(
+                        self.store.scope(state: \.login, action: \.login)
+                    ) { loginStore in
+                        LoginView(store: loginStore)
+                    }
+                }
             }
         }
+        .animation(.easeInOut(duration: 0.4), value: store.splash == nil)
     }
 }
 

--- a/Soongan/Soongan/Sources/SoonganApp.swift
+++ b/Soongan/Soongan/Sources/SoonganApp.swift
@@ -62,9 +62,6 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         // UNUserNotificationCenter delegate 설정
         UNUserNotificationCenter.current().delegate = self
         
-        // 원격 알림 권한 요청
-        requestNotificationPermission()
-        
         return true
     }
     

--- a/Soongan/Tuist/Package.swift
+++ b/Soongan/Tuist/Package.swift
@@ -9,18 +9,8 @@ import PackageDescription
         // Default is .staticFramework
         // productTypes: ["Alamofire": .framework,]
         productTypes: [
-            "KakaoSDKCommon": .framework,
-            "KakaoSDKAuth": .framework,
-            "KakaoSDKUser": .framework,
-            "ComposableArchitecture": .framework,
             "ComposableArchitectureMacros": .macro,
             "Alamofire": .framework,
-//            "FirebaseAnalytics": .framework,
-//            "FirebaseMessaging": .framework,
-//            "FirebaseCore": .framework,
-//            "FirebaseCoreInternal": .framework,
-//            "FirebaseInstallations": .framework,
-//            "GoogleUtilities": .framework,
         ]
     )
 #endif


### PR DESCRIPTION
## 📟 관련 이슈
- Resolved: #33 

<br>

## 👷 작업한 내용
<!-- 작업한 내용을 적어주세요. -->
- 스플래시 화면을 구현하고 앱 시작 로직을 통합
- 강제 업데이트 확인을 위한 앱 버전 비교 기능을 추가
- `AppVersionClient` 및 `NotificationClient` 의존성을 정의
- Tuist 의존성 관리 방식을 중앙화하여 리팩토링

<br>

## 📸 스크린샷
|기능|스플래쉬 화면 (강제 업데이트 x)|스플래쉬 화면 (강제 업데이트 o)|
|:--:|:--:|:--:|
|Img|<img src = "https://github.com/user-attachments/assets/11ed0f59-b3fe-47a9-955f-8871bb1f18a8" width ="250">|<img src = "https://github.com/user-attachments/assets/5e4b7a80-a0fb-467e-86e3-da7e20cec648" width ="250">|

<br>

## 🚨 참고 사항
<!-- 참고 사항을 적어주세요. 없으면 지워주세요. -->

### 1. 앱 아키텍처 변경: `SplashFeature` 도입
   - 기존에 `AppFeature` 가 담당하던 초기 분기 처리를 `SplashFeature` 로 이전하여, 앱의 진입점(Entry Point) 역할을 명확히 분리했습니다.
   - 실행 흐름: `onAppear` -> `clock.sleep` (1.5초) -> 버전 체크 -> `delegate` 를 통한 `AppFeature` 로 제어권 이전
   - 추후 유지보수 및 확장성을 고려한 아키텍처로 개선했습니다.

### 2. 의존성 클라이언트 설계
프레임워크에 직접 의존하지 않고, 테스트 용이성 및 모듈 간 결합도 감소를 위해 주요 기능들을 클라이언트로 추상화했습니다.
- `AppVersionClient`: `Bundle.main` API 를 추상화하여 앱의 현재 버전을 안정적으로 가져옵니다.
- `NotificationClient`: `UNUserNotificationCenter` API 를 추상화하여 알림 권한 요청 로직을 캡슐화합니다.

- 사용법: 각 클라이언트는 TCA의 @Dependency 프로퍼티 래퍼를 통해 어떤 모듈에서든 주입받아 사용할 수 있습니다.

``` Swift
@Dependency(\.appVersionClient) var appVersionClient
@Dependency(\.notificationClient) var notificationClient
```

### 3. Tuist 의존성 관리 리팩토링
- 문제점: 이전에는 각 Feature 모듈이 개별적으로 외부 라이브러리(Package)를 선언하여, 버전 불일치 및 빌드 설정의 복잡성을 유발할 수 있었습니다.
- 개선점: 모든 외부 라이브러리 선언을 최상단 `Tuist/Package.swift` 로 통합하여, 의존성 관리를 중앙화하고 프로젝트 전체의 빌드 일관성을 확보했습니다. 향후 라이브러리 업데이트 및 관리 복잡도를 크게 낮춥니다.

<br>

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
