### PR TITLE
[Feat] #40 - 콘테스트 세부사항 수정 관련 API 변경사항 반영

### DIFF
--- a/Soongan/.package.resolved
+++ b/Soongan/.package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "81d703dd6e7ef361d922e4159d56e99fa7337762368097761b4ba0ff022b4d31",
+  "originHash" : "8823f42c121e2bd59c7065deafaa6b94a0ad3634a0538fbca4b0a4fb79b4fb03",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -8,15 +8,6 @@
       "state" : {
         "revision" : "5928286acce13def418ec36d05a001a9641086f2",
         "version" : "1.0.3"
-      }
-    },
-    {
-      "identity" : "swift-case-paths",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/swift-case-paths",
-      "state" : {
-        "revision" : "41b89b8b68d8c56c622dbb7132258f1a3e638b25",
-        "version" : "1.7.0"
       }
     },
     {
@@ -29,24 +20,6 @@
       }
     },
     {
-      "identity" : "swift-collections",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-collections",
-      "state" : {
-        "revision" : "671108c96644956dddcd89dd59c203dcdb36cec7",
-        "version" : "1.1.4"
-      }
-    },
-    {
-      "identity" : "swift-composable-architecture",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/swift-composable-architecture.git",
-      "state" : {
-        "revision" : "b1d27a82b498b8e697acabd8cc01b585d26aab19",
-        "version" : "1.19.1"
-      }
-    },
-    {
       "identity" : "swift-concurrency-extras",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-concurrency-extras",
@@ -56,57 +29,12 @@
       }
     },
     {
-      "identity" : "swift-custom-dump",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/swift-custom-dump",
-      "state" : {
-        "revision" : "82645ec760917961cfa08c9c0c7104a57a0fa4b1",
-        "version" : "1.3.3"
-      }
-    },
-    {
       "identity" : "swift-dependencies",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-dependencies",
       "state" : {
         "revision" : "4c90d6b2b9bf0911af87b103bb40f41771891596",
         "version" : "1.9.2"
-      }
-    },
-    {
-      "identity" : "swift-identified-collections",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/swift-identified-collections",
-      "state" : {
-        "revision" : "322d9ffeeba85c9f7c4984b39422ec7cc3c56597",
-        "version" : "1.1.1"
-      }
-    },
-    {
-      "identity" : "swift-navigation",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/swift-navigation",
-      "state" : {
-        "revision" : "db6bc9dbfed001f21e6728fd36413d9342c235b4",
-        "version" : "2.3.0"
-      }
-    },
-    {
-      "identity" : "swift-perception",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/swift-perception",
-      "state" : {
-        "revision" : "d924c62a70fca5f43872f286dbd7cef0957f1c01",
-        "version" : "1.6.0"
-      }
-    },
-    {
-      "identity" : "swift-sharing",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/swift-sharing",
-      "state" : {
-        "revision" : "732871fabfc6b38fcdff5ad2f7336327dbf78e81",
-        "version" : "2.4.0"
       }
     },
     {

--- a/Soongan/Core/CoreNetwork/Sources/WeeklyContest/DTO/Response/SearchDetailContestResponseDTO.swift
+++ b/Soongan/Core/CoreNetwork/Sources/WeeklyContest/DTO/Response/SearchDetailContestResponseDTO.swift
@@ -17,4 +17,7 @@ public struct SearchDetailContestResponseDTO: Decodable {
     public let likeCount: Int
     public let isLiked: Bool
     public let commentCount: Int
+    public let isTop7: Bool
+    public let weeklyContestRound: Int
+    public let weeklyContestSubject: String
 }

--- a/Soongan/Feature/ContestFeature/Sources/Logic/ContestFeature.swift
+++ b/Soongan/Feature/ContestFeature/Sources/Logic/ContestFeature.swift
@@ -265,10 +265,11 @@ public struct ContestFeature {
                     return .none
                 case .contestDetail(.delegate(.didRequestLogout)):
                     return .send(.delegate(.logoutRequested))
-                case .contestDetail(.delegate(.editRequested(let contestId, let title, let imageURL, let weekTopic))):
+                case .contestDetail(.delegate(.editRequested(let contestId, let round, let title, let imageURL, let weekTopic))):
                     let editState = PostPictureFeature.State(
                         mode: .edit(
                             contestId: contestId,
+                            weekRound: round,
                             weekTopic: weekTopic,
                             existingTitle: title,
                             imageURL: imageURL

--- a/Soongan/Feature/DetailContestFeature/Sources/Logic/ContestDetailFeature.swift
+++ b/Soongan/Feature/DetailContestFeature/Sources/Logic/ContestDetailFeature.swift
@@ -24,6 +24,7 @@ public struct ContestDetailFeature {
         @Shared(.appStorage("AuthState")) var authState: AuthType = .loggedOut
         
         var postId: Int
+        var postRound: Int?
         var postUserId: Int?
         var myNickname: String?
         var weekTopic: String
@@ -47,6 +48,8 @@ public struct ContestDetailFeature {
         var activeSheet: SheetContentType?
         var reportReasonSheet: SheetContentType?
         var completeReportSheet: SheetContentType?
+        
+        var alertSheet: AlertType?
         
         var pendingSheetAction: DetailContestOptionType? = nil
         
@@ -79,18 +82,11 @@ public struct ContestDetailFeature {
         case alertAction(AlertAction)
         case networkAction(NetworkAction)
         case uiAction(UIAction)
+        case sheetAction(SheetAction)
         
         case onAppear
-        case editButtonTapped
-        case reportReasonButtonTapped(type: ContestReportReasonType, reason: String)
-        case postReport(type: ContestReportReasonType)
-        case reportSuccess(ReportResponseDTO, ContestReportReasonType)
-        
-        case deleteOptionButtonTapped
+
         case deleteButtonTapped
-        case contestImageTapped
-        
-        case reportSheetIsPresented
         case optionSheetIsPresented(ContestReportReasonType)
         case completeReportSheetIsPresented(ContestReportReasonType)
         case dismissOptionSheet(Bool)
@@ -105,16 +101,13 @@ public struct ContestDetailFeature {
         case deleteActionResult(Bool)
         case deleteCompletedButtonTapped
         case presentDeleteAlert
-        case dismissDeleteAlert
-        
-        case optionSheetDismissed
         
         case delegate(DelegateAction)
 
         public enum DelegateAction {
             case backConfirmed
             case didRequestLogout
-            case editRequested(contestId: Int, title: String, imageURL: String, weekTopic: String)
+            case editRequested(contestId: Int, round: Int, title: String, imageURL: String, weekTopic: String)
         }
     }
     
@@ -123,6 +116,16 @@ public struct ContestDetailFeature {
         case presentLoginAlert
         case dismissAlertButtonTapped
         case dismissLoginAlert
+        case dismissAlert
+    }
+    
+    public enum SheetAction {
+        case optionSheetDismissed
+        
+        case reportReasonButtonTapped(type: ContestReportReasonType, reason: String)
+        case editButtonTapped
+        case deleteOptionButtonTapped
+        case reportSheetIsPresented
     }
     
     public enum NetworkAction {
@@ -131,11 +134,14 @@ public struct ContestDetailFeature {
         case fetchLikeContest
         case likeContestSuccess(isLike: Bool, PostLikeResponseDTO)
         case likeContestFailure(NetworkError)
+        case postReport(type: ContestReportReasonType)
+        case reportSuccess(ReportResponseDTO, ContestReportReasonType)
     }
     
     public enum UIAction {
         case likeButtonTapped
         case optionButtonTapped
+        case contestImageTapped
     }
     
     // MARK: - Body
@@ -167,6 +173,8 @@ public struct ContestDetailFeature {
                 
             case .networkAction(.onAppearDetailContestSuccess(let response)):
                 state.postUserId = response.authorMemberId
+                state.postRound = response.weeklyContestRound
+                state.weekTopic = response.weeklyContestSubject
                 state.contestTitle = response.title
                 state.contestAuthor = response.nickname
                 state.imageUrl = response.imageUrl
@@ -177,12 +185,6 @@ public struct ContestDetailFeature {
                 
             case .networkAction(.onAppearDetailContestFailure(let error)):
                 // TODO: - Error 처리
-                
-                return .none
-                
-            case .reportSheetIsPresented:
-                state.pendingSheetAction = .report
-                state.isContestOptionSheetPresented = false
                 
                 return .none
                 
@@ -211,18 +213,20 @@ public struct ContestDetailFeature {
                 
                 return .none
                 
-            case .optionSheetDismissed:
+            case .sheetAction(.optionSheetDismissed):
                 guard let action = state.pendingSheetAction else { return .none }
                 state.pendingSheetAction = nil
                 
                 switch action {
                 case .edit:
                     guard let title = state.contestTitle,
-                          let imageURL = state.imageUrl else { return .none }
+                          let imageURL = state.imageUrl,
+                          let round = state.postRound else { return .none }
                     
                     return .run { [contestId = state.postId, weekTopic = state.weekTopic] send in
                         await send(.delegate(.editRequested(
                             contestId: contestId,
+                            round: round,
                             title: title,
                             imageURL: imageURL,
                             weekTopic: weekTopic
@@ -234,9 +238,8 @@ public struct ContestDetailFeature {
                     
                 case .report:
                     state.isReportOptionSheetPresented = true
+                    return .none
                 }
-                
-                return .none
                 
             case .completeReportSheetIsPresented(let type):
                 state.completeReportSheet = .reportComplete(type: type)
@@ -276,16 +279,27 @@ public struct ContestDetailFeature {
                 // TODO: - 좋아요 에러
                 return .none
                 
-            case .editButtonTapped:
+            case .sheetAction(.editButtonTapped):
                 state.pendingSheetAction = .edit
+                state.isContestOptionSheetPresented = false
+                
+                return .none
+            
+            case .sheetAction(.deleteOptionButtonTapped):
+                state.pendingSheetAction = .delete
+                state.isContestOptionSheetPresented = false
+
+                return .none
+                
+            case .sheetAction(.reportSheetIsPresented):
+                state.pendingSheetAction = .report
                 state.isContestOptionSheetPresented = false
                 
                 return .none
                 
             case .deleteButtonTapped:
-                state.pendingSheetAction = .delete
-                state.isDeleteAlertPresented = false
-                
+                state.alertSheet = nil
+
                 let postId = state.postId
                 return .run { send in
                     let result: Result<EmptyResponseDTO, NetworkError> = await NetworkManager.shared.request(WeeklyContestEndpoint.deleteContest(postId: postId))
@@ -302,38 +316,24 @@ public struct ContestDetailFeature {
                 
             case .deleteActionResult(let result):
                 if result {
-                    state.isDeleteCompleteAlertPresented = true
+                    state.alertSheet = .deletePostComplete
                     return .none
                 } else {
                     return .none
                 }
-            
-            case .deleteOptionButtonTapped:
-                state.isContestOptionSheetPresented = false
-                
-                return .run { send in
-                    try await Task.sleep(nanoseconds: 500_000_000)
-                    await send(.presentDeleteAlert)
-                }
                 
             case .presentDeleteAlert:
-                state.isDeleteAlertPresented = true
-                
+                state.alertSheet = .deletePost
                 return .none
             
             case .deleteCompletedButtonTapped:
-                state.isDeleteCompleteAlertPresented = false
+                state.alertSheet = nil
                 
                 return .run { send in
                     try await Task.sleep(nanoseconds: 300_000_000)
                     await send(.delegate(.backConfirmed))
                 }
-                
-            case .dismissDeleteAlert:
-                state.isDeleteAlertPresented = false
-                
-                return .none
-                
+            
             case .dismissOptionSheet:
                 state.isContestOptionSheetPresented = false
                 return .none
@@ -346,7 +346,7 @@ public struct ContestDetailFeature {
                 state.activeSheet = nil
                 return .none
             
-            case .contestImageTapped:
+            case .uiAction(.contestImageTapped):
                 state.isFullSizeImageSheetPresented = true
                 
                 return .none
@@ -373,7 +373,7 @@ public struct ContestDetailFeature {
             case .backButtonTapped:
                 return .send(.delegate(.backConfirmed))
                 
-            case .postReport(let type):
+            case .networkAction(.postReport(let type)):
                 let dto = ReportRequestDTO(
                     targetId: state.postId,
                     targetType: "WEEKLY_POST",
@@ -386,17 +386,17 @@ public struct ContestDetailFeature {
                     
                     switch result {
                     case .success(let responseResult):
-                        await send(.reportSuccess(responseResult, type))
+                        await send(.networkAction(.reportSuccess(responseResult, type)))
                     case .failure(let error):
                         break
                     }
                 }
                 
-            case .reportSuccess(let response, let type):
+            case .networkAction(.reportSuccess(let response, let type)):
                 state.reportReason = nil
                 return .send(.completeReportSheetIsPresented(type))
                 
-            case .reportReasonButtonTapped(let type, let reason):
+            case .sheetAction(.reportReasonButtonTapped(let type, let reason)):
                 state.reportReason = reason
 
                 switch type {
@@ -428,6 +428,11 @@ public struct ContestDetailFeature {
                 
             case .alertAction(.dismissLoginAlert):
                 state.isLoginAlertPresented = false
+                return .none
+            
+            case .alertAction(.dismissAlert):
+                state.alertSheet = nil
+                state.pendingSheetAction = nil
                 return .none
                 
             default:

--- a/Soongan/Feature/DetailContestFeature/Sources/View/ContestDetailView.swift
+++ b/Soongan/Feature/DetailContestFeature/Sources/View/ContestDetailView.swift
@@ -34,22 +34,26 @@ public struct ContestDetailView: View {
             .background(DesignSystem.Color.soonganBG)
             .background(InteractivePopGestureEnabler())
             .fullScreenCover(item: $store.alertSheet) { alertType in
-                CustomAlertView(
-                    type: alertType,
-                    leftButtonAction: {
-                        store.send(.alertAction(.dismissAlert))
-                    },
-                    rightButtonAction: {
-                        switch alertType {
-                        case .deletePost:
+                if alertType == .deletePost {
+                    CustomAlertView(
+                        type: alertType,
+                        leftButtonAction: {
+                            store.send(.alertAction(.dismissAlert))
+                        },
+                        rightButtonAction: {
                             store.send(.deleteButtonTapped)
-                        case .deletePostComplete:
-                            store.send(.deleteCompletedButtonTapped)
-                        default:
-                            break
                         }
-                    }
-                ).presentationBackground(.clear)
+                    ).presentationBackground(.clear)
+                }
+                
+                if alertType == .deletePostComplete {
+                    CustomAlertView(
+                        type: alertType,
+                        centerButtonAction: {
+                            store.send(.deleteCompletedButtonTapped)
+                        }
+                    ).presentationBackground(.clear)
+                }
             }
             .transaction { transaction in
                 transaction.disablesAnimations = true

--- a/Soongan/Feature/DetailContestFeature/Sources/View/ContestDetailView.swift
+++ b/Soongan/Feature/DetailContestFeature/Sources/View/ContestDetailView.swift
@@ -33,22 +33,21 @@ public struct ContestDetailView: View {
             .ignoresSafeArea(edges: .bottom)
             .background(DesignSystem.Color.soonganBG)
             .background(InteractivePopGestureEnabler())
-            .fullScreenCover(isPresented: $store.isDeleteAlertPresented) {
+            .fullScreenCover(item: $store.alertSheet) { alertType in
                 CustomAlertView(
-                    type: .deletePost,
+                    type: alertType,
                     leftButtonAction: {
-                        store.send(.dismissDeleteAlert)
+                        store.send(.alertAction(.dismissAlert))
                     },
                     rightButtonAction: {
-                        store.send(.deleteButtonTapped)
-                    }
-                ).presentationBackground(.clear)
-            }
-            .fullScreenCover(isPresented: $store.isDeleteCompleteAlertPresented) {
-                CustomAlertView(
-                    type: .deletePostComplete,
-                    centerButtonAction: {
-                        store.send(.deleteCompletedButtonTapped)
+                        switch alertType {
+                        case .deletePost:
+                            store.send(.deleteButtonTapped)
+                        case .deletePostComplete:
+                            store.send(.deleteCompletedButtonTapped)
+                        default:
+                            break
+                        }
                     }
                 ).presentationBackground(.clear)
             }
@@ -57,19 +56,19 @@ public struct ContestDetailView: View {
             }
             .sheet(
                 isPresented: $store.isContestOptionSheetPresented.sending(\.dismissOptionSheet),
-                onDismiss: { store.send(.optionSheetDismissed) }
+                onDismiss: { store.send(.sheetAction(.optionSheetDismissed)) }
             ) {
                 CustomSheetView<DetailContestOptionType>(type: .detailContestOption(isWriter: store.isWriter)) { type in
                     switch type {
                     case .edit:
-                        store.send(.editButtonTapped)
+                        store.send(.sheetAction(.editButtonTapped))
                     case .delete:
-                        store.send(.deleteOptionButtonTapped)
+                        store.send(.sheetAction(.deleteOptionButtonTapped))
                     case .report:
                         if store.authState == .skipped {
                             store.send(.alertAction(.notAuthUserAlert))
                         } else {
-                            store.send(.reportSheetIsPresented)
+                            store.send(.sheetAction(.reportSheetIsPresented))
                         }
                     }
                 }
@@ -83,12 +82,12 @@ public struct ContestDetailView: View {
             }
             .sheet(item: $store.activeSheet) { sheetType in
                 CustomSheetView<ContestReportReasonType>(type: sheetType) { type, reportReason in
-                    store.send(.postReport(type: type))
+                    store.send(.networkAction(.postReport(type: type)))
                 }
             }
             .sheet(item: $store.reportReasonSheet) { sheetType in
                 CustomSheetView<NeverOption>(type: sheetType) { reportType, reasonText in
-                    store.send(.reportReasonButtonTapped(type: reportType, reason: reasonText))
+                    store.send(.sheetAction(.reportReasonButtonTapped(type: reportType, reason: reasonText)))
                 }
             }
             .sheet(item : $store.completeReportSheet) { sheetType in
@@ -129,7 +128,7 @@ public struct ContestDetailView: View {
                         .aspectRatio(contentMode: .fit)
                         .frame(maxWidth: 360, maxHeight: 460, alignment: .center)
                         .onTapGesture {
-                            store.send(.contestImageTapped)
+                            store.send(.uiAction(.contestImageTapped))
                         }
                 }
                 

--- a/Soongan/Feature/HomeFeature/Sources/Logic/HomeFeature.swift
+++ b/Soongan/Feature/HomeFeature/Sources/Logic/HomeFeature.swift
@@ -217,10 +217,11 @@ public struct HomeFeature {
                 case .contestDetail(.delegate(.backConfirmed)):
                     state.path.removeLast()
                     return .none
-                case .contestDetail(.delegate(.editRequested(let contestId, let title, let imageURL, let weekTopic))):
+                case .contestDetail(.delegate(.editRequested(let contestId, let round, let title, let imageURL, let weekTopic))):
                     let editState = PostPictureFeature.State(
                         mode: .edit(
                             contestId: contestId,
+                            weekRound: round,
                             weekTopic: weekTopic,
                             existingTitle: title,
                             imageURL: imageURL

--- a/Soongan/Feature/MypageFeature/Sources/Logic/MypageFeature.swift
+++ b/Soongan/Feature/MypageFeature/Sources/Logic/MypageFeature.swift
@@ -217,10 +217,11 @@ public struct MypageFeature {
                     state.path.removeLast()
                     return .none
                     
-                case .contestDetail(.delegate(.editRequested(let contestId, let title, let imageURL, let weekTopic))):
+                case .contestDetail(.delegate(.editRequested(let contestId, let round, let title, let imageURL, let weekTopic))):
                     let editState = PostPictureFeature.State(
                         mode: .edit(
                             contestId: contestId,
+                            weekRound: round,
                             weekTopic: weekTopic,
                             existingTitle: title,
                             imageURL: imageURL

--- a/Soongan/Feature/PostPictureFeature/Sources/Logic/PostPictureFeature.swift
+++ b/Soongan/Feature/PostPictureFeature/Sources/Logic/PostPictureFeature.swift
@@ -17,7 +17,7 @@ import Kingfisher
 
 public enum PostPictureMode: Equatable {
     case create(weekTopic: String)
-    case edit(contestId: Int, weekTopic: String, existingTitle: String, imageURL: String)
+    case edit(contestId: Int, weekRound: Int, weekTopic: String, existingTitle: String, imageURL: String)
 }
 
 @Reducer
@@ -47,7 +47,7 @@ public struct PostPictureFeature {
             switch mode {
             case .create(let topic):
                 return topic
-            case .edit(_, let topic, _, _):
+            case .edit(_, _, let topic, _, _):
                 return topic
             }
         }
@@ -65,7 +65,7 @@ public struct PostPictureFeature {
             switch mode {
             case .create:
                 return nil
-            case .edit(let id, _, _, _):
+            case .edit(let id, _, _, _, _):
                 return id
             }
         }
@@ -76,7 +76,8 @@ public struct PostPictureFeature {
             switch mode {
             case .create:
                 break
-            case .edit(_, _, let title, _):
+            case .edit(_, let round, _, let title, _):
+                self.round = round
                 self.postPictureName = title
                 self.textCount = title.count
                 self.isButtonEnabled = (self.textCount > 0) && (self.textCount < 16)
@@ -135,7 +136,7 @@ public struct PostPictureFeature {
                 
             case .onAppear:
                 // Edit 모드일 때 기존 이미지 로드
-                if case .edit(_, _, _, let imageURL) = state.mode {
+                if case .edit(_, _, _, _, let imageURL) = state.mode {
                     return .run { send in
                         guard let url = URL(string: imageURL) else { return }
                         
@@ -175,7 +176,7 @@ public struct PostPictureFeature {
                     state.isPostSheetPresented = true
                     return .none
                     
-                case .edit(let contestId, _, _, _):
+                case .edit(let contestId, _, _, _, _):
                     // 수정 요청
                     let dto = PutWeeklyContestRequestDTO(
                         title: state.postPictureName

--- a/Soongan/Tuist/Package.resolved
+++ b/Soongan/Tuist/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "c9354e6c35a7813898d2b0a0bfc154e6486a41755bc9b6b2e6143aa2fdf143a7",
+  "originHash" : "6e480b5796db891350c9f90ab636a712a0ccd59c8bf5db0bcaa14bfd215703c9",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -177,8 +177,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-composable-architecture.git",
       "state" : {
-        "revision" : "2ebda6ae2b155a5c3d75aff5f6d25c024bc91311",
-        "version" : "1.17.1"
+        "revision" : "acd9bb8a7cf6e36a89d81a432c2e8eb3b1bb3771",
+        "version" : "1.22.2"
       }
     },
     {
@@ -222,8 +222,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-navigation",
       "state" : {
-        "revision" : "db6bc9dbfed001f21e6728fd36413d9342c235b4",
-        "version" : "2.3.0"
+        "revision" : "6b7f44d218e776bb7a5246efb940440d57c8b2cf",
+        "version" : "2.4.2"
       }
     },
     {

--- a/Soongan/Tuist/Package.swift
+++ b/Soongan/Tuist/Package.swift
@@ -23,7 +23,8 @@ let package = Package(
         // You can read more about dependencies here: https://docs.tuist.io/documentation/tuist/dependencies
         
         .package(url: "https://github.com/kakao/kakao-ios-sdk", from: "2.24.0"),
-        .package(url: "https://github.com/pointfreeco/swift-composable-architecture.git", exact: "1.17.1"),
+        .package(url: "https://github.com/pointfreeco/swift-composable-architecture.git", from: "1.18.0"),
+        .package(url: "https://github.com/pointfreeco/swift-navigation", from: "2.4.0"),
         .package(url: "https://github.com/Alamofire/Alamofire.git", from: "5.8.1"),
         .package(url: "https://github.com/firebase/firebase-ios-sdk.git", from: "10.24.0"),
         .package(url: "https://github.com/onevcat/Kingfisher.git", .upToNextMajor(from: "7.10.0"))

--- a/Soongan/mise.toml
+++ b/Soongan/mise.toml
@@ -1,2 +1,2 @@
 [tools]
-tuist = "4.47.0"
+tuist = "latest"

--- a/Soongan/mise.toml
+++ b/Soongan/mise.toml
@@ -1,2 +1,2 @@
 [tools]
-tuist = "latest"
+tuist = "4.47.0"


### PR DESCRIPTION
## 📟 관련 이슈
- Resolved: #40 

<br>

## 👷 작업한 내용
<!-- 작업한 내용을 적어주세요. -->
 - Xcode 26 및 Swift 6.0 마이그레이션 대응
- swift-composable-architecture 라이브러리 의존성 수정
- ContestDetailFeature 의 Action 을 리팩토링
- 콘테스트 세부사항 API 변경사항 반영

<br>

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "https://github.com/user-attachments/assets/9a2b4161-b35c-49b9-9672-eb9c0a60f6c5" width ="250">|

<br>

## 🚨 참고 사항
<!-- 참고 사항을 적어주세요. 없으면 지워주세요. -->
- Xcode 26 및 Swift 6.0 대응
     - mise.toml 설정을 통해 Tuist를 최신 버전으로 업데이트
     - Tuist/Package.swift의 라이브러리 의존성을 Swift 6.0 호환 버전으로 수정 (TCA, Swift-Navigation)

- ContestDetailFeature 리팩토링
     - Feature의 Action을 `UIAction`, `SheetAction`, `NetworkAction` 등으로 분리하여 코드 구조 개선
     - 여러 개의 `isPresented` 를 사용하던 Alert 로직을  `fullScreenCover(item:)` 으로 사용하도록 개선
     - `Sheet` 의 `onDismiss` 로직에서 상태가 `nil` 이 되는 문제를 해결하고, 관련된 액션 로직 수정

- API 변경사항 반영
     - `SearchDetailContestResponseDTO` 에 `isTop7`, `weeklyContestRound`, `weeklyContestSubject` 필드 추가
     - `round` 정보가 추가됨에 따라 `editRequested` 등 관련 피처의 모델 및 로직 수정

<br>


## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
