### PR TITLE
[Feat] #43 - 신고한 게시물 숨기기 로직 구현 및 소셜 로그인 로직 리펙토링

### DIFF
--- a/Soongan/Core/CoreAppleLogin/Sources/AppleLoginError.swift
+++ b/Soongan/Core/CoreAppleLogin/Sources/AppleLoginError.swift
@@ -8,5 +8,24 @@
 import Foundation
 
 public enum AppleLoginError: Error {
-    case noCredential
+    case noCredential              // 인증 정보 없음
+    case userCancelled             // 사용자 취소
+    case invalidResponse           // 잘못된 응답
+    case networkError              // 네트워크 오류
+    case unknown                   // 알 수 없는 오류
+    
+    public var localizedDescription: String {
+        switch self {
+        case .noCredential:
+            return "인증 정보를 가져올 수 없습니다"
+        case .userCancelled:
+            return "사용자가 로그인을 취소했습니다"
+        case .invalidResponse:
+            return "잘못된 응답을 받았습니다"
+        case .networkError:
+            return "네트워크 연결에 문제가 있습니다"
+        case .unknown:
+            return "알 수 없는 오류가 발생했습니다"
+        }
+    }
 }

--- a/Soongan/Core/CoreAppleLogin/Sources/AppleLoginService.swift
+++ b/Soongan/Core/CoreAppleLogin/Sources/AppleLoginService.swift
@@ -34,22 +34,47 @@ extension AppleLoginService: ASAuthorizationControllerDelegate {
         
         guard let credential = authorization.credential as? ASAuthorizationAppleIDCredential else {
             continuation?.resume(throwing: AppleLoginError.noCredential)
+            continuation = nil
             return
         }
         
         guard let identityTokenData = credential.identityToken,
               let identityToken = String(data: identityTokenData, encoding: .utf8) else {
             continuation?.resume(throwing: AppleLoginError.noCredential)
+            continuation = nil
             return
         }
 
         print("애플로그인 결과 반환", identityToken)
 
         continuation?.resume(returning: identityToken)
+        continuation = nil
    }
 
    public func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
-       continuation?.resume(throwing: error)
+       let appleError: AppleLoginError
+       
+       if let authError = error as? ASAuthorizationError {
+           switch authError.code {
+           case .canceled:
+               appleError = .userCancelled
+           case .invalidResponse:
+               appleError = .invalidResponse
+           case .notHandled:
+               appleError = .invalidResponse
+           case .failed:
+               appleError = .networkError
+           case .unknown:
+               appleError = .unknown
+           default:
+               appleError = .unknown
+           }
+       } else {
+           appleError = .unknown
+       }
+       
+       continuation?.resume(throwing: appleError)
+       continuation = nil
    }
 }
 

--- a/Soongan/Core/CoreAppleLogin/Sources/AppleLoginService.swift
+++ b/Soongan/Core/CoreAppleLogin/Sources/AppleLoginService.swift
@@ -58,14 +58,10 @@ extension AppleLoginService: ASAuthorizationControllerDelegate {
            switch authError.code {
            case .canceled:
                appleError = .userCancelled
-           case .invalidResponse:
-               appleError = .invalidResponse
-           case .notHandled:
+           case .invalidResponse, .notHandled:
                appleError = .invalidResponse
            case .failed:
                appleError = .networkError
-           case .unknown:
-               appleError = .unknown
            default:
                appleError = .unknown
            }

--- a/Soongan/Core/CoreKakaoLogin/Sources/KakaoLoginError.swift
+++ b/Soongan/Core/CoreKakaoLogin/Sources/KakaoLoginError.swift
@@ -8,7 +8,27 @@
 import Foundation
 
 public enum KakaoLoginError: Error {
-    case tokenIssueFailed
-    case userInfoFailed
-    case unknown
+    case tokenIssueFailed          // 토큰 발급 실패
+    case userInfoFailed           // 사용자 정보 조회 실패
+    case userCancelled            // 사용자 취소
+    case networkError             // 네트워크 오류
+    case appNotInstalled          // 카카오톡 앱 미설치
+    case unknown                  // 알 수 없는 오류
+    
+    public var localizedDescription: String {
+        switch self {
+        case .tokenIssueFailed:
+            return "카카오 토큰 발급에 실패했습니다"
+        case .userInfoFailed:
+            return "카카오 사용자 정보 조회에 실패했습니다"
+        case .userCancelled:
+            return "사용자가 로그인을 취소했습니다"
+        case .networkError:
+            return "네트워크 연결에 문제가 있습니다"
+        case .appNotInstalled:
+            return "카카오톡 앱이 설치되지 않았습니다"
+        case .unknown:
+            return "알 수 없는 오류가 발생했습니다"
+        }
+    }
 }

--- a/Soongan/DesignSystem/Sources/Component/CustomAlertView.swift
+++ b/Soongan/DesignSystem/Sources/Component/CustomAlertView.swift
@@ -7,9 +7,17 @@
 
 import SwiftUI
 
-public struct CustomAlertView: View {
+public protocol AlertDisplayable: Identifiable {
+    var title: String { get }
+    var centerButtonTitle: String { get }
+}
+
+// 기존 코드 호환성을 위한 타입 별칭
+public typealias DefaultCustomAlertView = CustomAlertView<AlertType>
+
+public struct CustomAlertView<T: AlertDisplayable>: View {
     
-    private var type: AlertType
+    private var type: T
     private var onBackgroundTap: (() -> Void)?
     private var centerButtonAction: (() -> Void)?
     private var leftButtonAction: (() -> Void)?
@@ -18,7 +26,7 @@ public struct CustomAlertView: View {
     // MARK: - Init
     
     public init(
-        type: AlertType,
+        type: T,
         onBackgroundTap: (() -> Void)? = nil,
         centerButtonAction: (() -> Void)? = nil,
         leftButtonAction: (() -> Void)? = nil,
@@ -117,23 +125,25 @@ public struct CustomAlertView: View {
 }
 
 #Preview {
-    CustomAlertView(type: .postContestError, centerButtonAction: {  })
+    CustomAlertView(type: AlertType.postContestError, centerButtonAction: {  })
 }
 
-public enum AlertType: Identifiable {
+public enum AlertType: AlertDisplayable {
     case postContestError
     case backPostContest
     case backEditContest
     case showLoginView
     case deletePost
     case deletePostComplete
+    case deleteContainPostToTop7
+    case editContainPostToTop7
     case forceUpdate
     
     public var id: Self {
         self
     }
     
-    var title: String {
+    public var title: String {
         switch self {
         case .postContestError:
             return "콘테스트가 마감됐어요."
@@ -147,12 +157,16 @@ public enum AlertType: Identifiable {
             return "정말 작품을\n삭제하시겠습니까?"
         case .deletePostComplete:
             return "삭제가 완료되었습니다"
+        case .deleteContainPostToTop7:
+            return "TOP 7에 선정된 작품은\n삭제할 수 없습니다."
+        case .editContainPostToTop7:
+            return "TOP 7에 선정된 작품은\n수정할 수 없습니다."
         case .forceUpdate:
             return "원활한 앱 활동을 위해\n버전 업데이트가 필요합니다."
         }
     }
     
-    var centerButtonTitle: String {
+    public var centerButtonTitle: String {
         switch self {
         case .showLoginView:
             return "로그인하기"
@@ -162,5 +176,74 @@ public enum AlertType: Identifiable {
             return "확인"
         
         }
+    }
+}
+
+public enum LoginErrorType: AlertDisplayable, Equatable {
+    case socialLogin(title: String)
+    case serverAuth
+    case profileFetch
+    case fcmTokenMissing
+    
+    public var id: String {
+        switch self {
+        case .socialLogin(let title):
+            return "\(title)socialLogin"
+        case .serverAuth:
+            return "serverAuth"
+        case .profileFetch:
+            return "profileFetch"
+        case .fcmTokenMissing:
+            return "fcmTokenMissing"
+        }
+    }
+    
+    public var title: String {
+        switch self {
+        case .socialLogin(let title):
+            return "\(title)에 실패했습니다."
+        case .serverAuth:
+            return "서버 인증에 실패했습니다.\n잠시 후 다시 시도해주세요."
+        case .profileFetch:
+            return "프로필 정보를 가져오는 데에 실패했습니다."
+        case .fcmTokenMissing:
+            return "FCM 인증에 실패했습니다. "
+        }
+    }
+    
+    public var centerButtonTitle: String {
+        return "확인"
+    }
+}
+
+public enum SignupErrorType: AlertDisplayable, Equatable {
+    case checkNicknameFailed
+    case editBrithDayFailed
+    case myprofileFailed
+    
+    public var id: String {
+        switch self {
+        case .checkNicknameFailed:
+            return "checkNicknameFailed"
+        case .editBrithDayFailed:
+            return "editBrithDayFailed"
+        case .myprofileFailed:
+            return "myprofileFailed"
+        }
+    }
+    
+    public var title: String {
+        switch self {
+        case .checkNicknameFailed:
+            return "닉네임 중복체크에 실패했습니다.\n잠시 후 다시 시도해주세요."
+        case .editBrithDayFailed:
+            return "출생연도 입력에 실패했습니다.\n잠시 후 다시 시도해주세요."
+        case .myprofileFailed:
+            return "회원가입에 실패했습니다.\n잠시 후 다시 시도해주세요."
+        }
+    }
+    
+    public var centerButtonTitle: String {
+        return "확인"
     }
 }

--- a/Soongan/DesignSystem/Sources/Component/CustomAlertView.swift
+++ b/Soongan/DesignSystem/Sources/Component/CustomAlertView.swift
@@ -207,7 +207,7 @@ public enum LoginErrorType: AlertDisplayable, Equatable {
         case .profileFetch:
             return "프로필 정보를 가져오는 데에 실패했습니다."
         case .fcmTokenMissing:
-            return "FCM 인증에 실패했습니다. "
+            return "FCM 인증에 실패했습니다."
         }
     }
     

--- a/Soongan/DesignSystem/Sources/Component/CustomTextFieldView.swift
+++ b/Soongan/DesignSystem/Sources/Component/CustomTextFieldView.swift
@@ -90,7 +90,7 @@ public struct CustomTextFieldView: View {
                     alignment: .trailing
                 )
             
-            if isFocused.wrappedValue == true || (type == .changeNickname || type == .introduce) {
+            if isFocused.wrappedValue == true || (type == .changeNickname || type == .introduce) || state == .error(message: .duplication) {
                 HStack(spacing: 0) {
                     switch state {
                     case .error(let errorMessage):

--- a/Soongan/Feature/AuthFeature/Sources/Logic/LoginFeature.swift
+++ b/Soongan/Feature/AuthFeature/Sources/Logic/LoginFeature.swift
@@ -80,12 +80,10 @@ public struct LoginFeature {
         case serverAuthSuccess
         case serverAuthFailure
         
-        case profileFetchSuccess(Bool)  // isSignupComplete
+        case profileFetchSuccess(SearchMyProfileResponseDTO)
         case profileFetchFailure
         
         case fcmFetchFailure
-        
-        case loginFailure(LoginError)
         
         case dismissAlert
 
@@ -180,51 +178,34 @@ public struct LoginFeature {
             case .serverAuthSuccess:
                 return .run { send in
                     let result: Result<SearchMyProfileResponseDTO, NetworkError> = await NetworkManager.shared.request(MemberEndpoint.getMembers)
-                    
                     switch result {
                     case .success(let myResult):
-                        let isSignupComplete = myResult.nickname != nil && myResult.birthYear != nil
-                        await send(.profileFetchSuccess(isSignupComplete))
-                        
-                    case .failure(_):
+                        await send(.profileFetchSuccess(myResult))
+                    case .failure:
                         await send(.profileFetchFailure)
                     }
                 }
-            
-            /// 서버 로그인 실패
+
             case .serverAuthFailure:
                 state.loginErrorAlert = .serverAuth
                 return .none
-                
-            case .profileFetchSuccess(let isSignupComplete):
+
+            case .profileFetchSuccess(let myResult):
+                let isSignupComplete = myResult.nickname != nil && myResult.birthYear != nil
                 if isSignupComplete {
-                    // 프로필 조회 성공 시 닉네임 저장
                     return .run { send in
-                        let result: Result<SearchMyProfileResponseDTO, NetworkError> = await NetworkManager.shared.request(MemberEndpoint.getMembers)
-                        
-                        switch result {
-                        case .success(let myResult):
-                            if let nickname = myResult.nickname {
-                                await userDefaultsClient.setString(nickname, forKey: UserDefaultKeys.User.username.rawValue)
-                            }
-                        case .failure:
-                            break
+                        if let nickname = myResult.nickname {
+                            await userDefaultsClient.setString(nickname, forKey: UserDefaultKeys.User.username.rawValue)
                         }
-                        
                         await send(.delegate(.loginSuccess))
                     }
                 } else {
-                    // 회원가입이 필요한 경우
                     state.path.append(.signup(SignupFeature.State()))
                     return .none
                 }
                 
             case .profileFetchFailure:
                 state.loginErrorAlert = .profileFetch
-                return .none
-                
-            case .loginFailure(let error):
-                state.errorMessage = "로그인 실패: \(error.localizedDescription)"
                 return .none
                 
             case .fcmFetchFailure:

--- a/Soongan/Feature/AuthFeature/Sources/Logic/LoginFeature.swift
+++ b/Soongan/Feature/AuthFeature/Sources/Logic/LoginFeature.swift
@@ -22,6 +22,13 @@ public enum LoginType: String {
     case apple = "APPLE"
 }
 
+public enum LoginError: Error {
+    case socialLogin(type: LoginType, error: Error)     // 소셜 로그인 단계 에러
+    case serverAuth(Error)                              // 서버 인증 단계 에러
+    case profileFetch(Error)                           // 프로필 조회 단계 에러
+    case fcmTokenMissing                              // FCM 토큰 없음
+}
+
 @Reducer
 public struct LoginFeature {
     
@@ -39,6 +46,8 @@ public struct LoginFeature {
     public struct State: Equatable {
         var path = StackState<LoginPath.State>()
         var errorMessage: String = ""
+        
+        var loginErrorAlert: LoginErrorType?
         
         public init() {}
     }
@@ -66,11 +75,19 @@ public struct LoginFeature {
         case appleButtonTapped
         
         case socialLoginSuccessResponse(type: LoginType, token: String)
-        case socialLoginFailureResponse(Error)
+        case socialLoginFailureResponse(type: LoginType, error: Error)
         
-        case loginSuccess
-        case isSignupComplete(Bool)
-        case loginFailure(Error)
+        case serverAuthSuccess
+        case serverAuthFailure
+        
+        case profileFetchSuccess(Bool)  // isSignupComplete
+        case profileFetchFailure
+        
+        case fcmFetchFailure
+        
+        case loginFailure(LoginError)
+        
+        case dismissAlert
 
         case skippLoginButtonTapped
         case termsOfUseButtonTapped
@@ -88,6 +105,8 @@ public struct LoginFeature {
     // MARK: - Body
     
     public var body: some ReducerOf<Self> {
+        BindingReducer()
+        
         Reduce { state, action in
             switch action {
             case .onAppear:
@@ -104,7 +123,7 @@ public struct LoginFeature {
                         let oauthToken = try await appleLoginService.login()
                         await send(.socialLoginSuccessResponse(type: .apple, token: oauthToken))
                     } catch {
-                        await send(.socialLoginFailureResponse(error))
+                        await send(.socialLoginFailureResponse(type: .apple, error: error))
                     }
                 }
                 
@@ -114,13 +133,16 @@ public struct LoginFeature {
                         let idToken = try await kakaoLoginService.login()
                         await send(.socialLoginSuccessResponse(type: .kakao, token: idToken))
                     } catch {
-                        await send(.socialLoginFailureResponse(error))
+                        await send(.socialLoginFailureResponse(type: .kakao, error: error))
                     }
                 }
                 
             case let .socialLoginSuccessResponse(type, token):
                 return .run { send in
-                    guard let fcmToken = KeychainManager.shared.load(key: .fcmToken) else { return }
+                    guard let fcmToken = KeychainManager.shared.load(key: .fcmToken) else { 
+                        await send(.fcmFetchFailure)
+                        return
+                    }
 
                     let result: Result<AuthedResponseDTO, NetworkError> = await NetworkManager.shared.request(
                         AuthEndpoint.postLogin(
@@ -137,43 +159,76 @@ public struct LoginFeature {
                         KeychainManager.shared.save(key: .accessToken, value: authedResult.accessToken)
                         KeychainManager.shared.save(key: .refreshToken, value: authedResult.refreshToken)
                         
-                        await send(.loginSuccess)
+                        await send(.serverAuthSuccess)
                         
-                    case .failure(let error):
-                        await send(.loginFailure(error))
+                    case .failure(_):
+                        await send(.serverAuthFailure)
                     }
                 }
                 
-            case .loginSuccess:
+            case .socialLoginFailureResponse(let type, let error):
+                switch type {
+                case .apple:
+                    state.loginErrorAlert = .socialLogin(title: "애플 로그인")
+                case .kakao:
+                    state.loginErrorAlert = .socialLogin(title: "카카오 로그인")
+                }
+
+                return .none
+                
+            /// 서버 로그인 성공
+            case .serverAuthSuccess:
                 return .run { send in
-                    let reulst: Result<SearchMyProfileResponseDTO, NetworkError> = await NetworkManager.shared.request(MemberEndpoint.getMembers)
+                    let result: Result<SearchMyProfileResponseDTO, NetworkError> = await NetworkManager.shared.request(MemberEndpoint.getMembers)
                     
-                    switch reulst {
+                    switch result {
                     case .success(let myResult):
-                        if myResult.nickname == nil && myResult.birthYear == nil {
-                            await send(.isSignupComplete(false))
-                        } else {
+                        let isSignupComplete = myResult.nickname != nil && myResult.birthYear != nil
+                        await send(.profileFetchSuccess(isSignupComplete))
+                        
+                    case .failure(_):
+                        await send(.profileFetchFailure)
+                    }
+                }
+            
+            /// 서버 로그인 실패
+            case .serverAuthFailure:
+                state.loginErrorAlert = .serverAuth
+                return .none
+                
+            case .profileFetchSuccess(let isSignupComplete):
+                if isSignupComplete {
+                    // 프로필 조회 성공 시 닉네임 저장
+                    return .run { send in
+                        let result: Result<SearchMyProfileResponseDTO, NetworkError> = await NetworkManager.shared.request(MemberEndpoint.getMembers)
+                        
+                        switch result {
+                        case .success(let myResult):
                             if let nickname = myResult.nickname {
                                 await userDefaultsClient.setString(nickname, forKey: UserDefaultKeys.User.username.rawValue)
                             }
-                            await send(.isSignupComplete(true))
+                        case .failure:
+                            break
                         }
                         
-                    case .failure(let error):
-                        await send(.loginFailure(error))
+                        await send(.delegate(.loginSuccess))
                     }
-                }
-
-            case .isSignupComplete(let isSignup):
-                if isSignup {
-                    return .send(.delegate(.loginSuccess))
                 } else {
+                    // 회원가입이 필요한 경우
                     state.path.append(.signup(SignupFeature.State()))
                     return .none
                 }
                 
+            case .profileFetchFailure:
+                state.loginErrorAlert = .profileFetch
+                return .none
+                
             case .loginFailure(let error):
                 state.errorMessage = "로그인 실패: \(error.localizedDescription)"
+                return .none
+                
+            case .fcmFetchFailure:
+                state.loginErrorAlert = .fcmTokenMissing
                 return .none
 
             case .termsOfUseButtonTapped:
@@ -212,6 +267,10 @@ public struct LoginFeature {
                 return .none
 
             case .path:
+                return .none
+                
+            case .dismissAlert:
+                state.loginErrorAlert = nil
                 return .none
                 
             default:

--- a/Soongan/Feature/AuthFeature/Sources/Logic/SignupFeature.swift
+++ b/Soongan/Feature/AuthFeature/Sources/Logic/SignupFeature.swift
@@ -35,6 +35,8 @@ public struct SignupFeature {
         var isNicknameFocused: Bool = false
         var isBirthdayFocused: Bool = false
         
+        var signupErrorAlert: SignupErrorType?
+        
         public init() {}
     }
     
@@ -54,11 +56,17 @@ public struct SignupFeature {
         case showSignupView
         case backButtonTapped
         
-        case checkNicknameResult
-        case editBirthDayResult
+        case checkNicknameSuccess
+        case checkNicknameFailure
+        
+        case completeSignup
+        case editBirthDayFailure
+        case fetchMyprofileFailed
         
         case nickNameError
         case birhDayError
+        
+        case dismissAlert
         
         // Delegate - SignupFeature -> LoginFeature
         case delegate(Delegate)
@@ -116,11 +124,15 @@ public struct SignupFeature {
                         let result: Result<Bool, NetworkError> = await NetworkManager.shared.request(MemberEndpoint.getCheckNickname(dto))
                         
                         switch result {
-                        case .success:
-                            await send(.checkNicknameResult)
+                        case .success(let response):
+                            if response { // 중복일때 false 반환
+                                await send(.checkNicknameSuccess)
+                            } else {
+                                await send(.nickNameError)
+                            }
                             
                         case .failure:
-                            await send(.nickNameError)
+                            await send(.checkNicknameFailure)
                         }
                     }
                 case .inputBirthday:
@@ -149,36 +161,58 @@ public struct SignupFeature {
                             
                             let (birthResult, profileResult) = await (myBirthResult, myprofileResult)
 
-                            if case .success = birthResult, case .success = profileResult {
-                                await send(.editBirthDayResult)
-                            } else {
-                                await send(.birhDayError)
-                            }
+                            switch (birthResult, profileResult) {
+                             case (.success, .success):
+                                 await send(.completeSignup)
+                            case (.success, .failure):
+                                await send(.fetchMyprofileFailed)
+                            case (.failure, .success):
+                                await send(.editBirthDayFailure)
+                             default:
+                                 await send(.editBirthDayFailure)
+                             }
                         }
                     } else {
                         return .send(.birhDayError)
                     }
                 }
                 
-            case .checkNicknameResult:
+            case .checkNicknameSuccess:
                 state.signupState = .inputBirthday
                 state.isButtonEnabled = false
                 
                 return .none
                 
-            case .editBirthDayResult:
+            case .checkNicknameFailure:
+                state.signupErrorAlert = .checkNicknameFailed
+                return .none
+                
+            case .fetchMyprofileFailed:
+                state.signupErrorAlert = .myprofileFailed
+                return .none
+                
+            case .editBirthDayFailure:
+                state.signupErrorAlert = .editBrithDayFailed
+                return .none
+                
+            case .completeSignup:
                 return .run { [nickname = state.nickname] send in
                     await userDefaultsClient.setString(nickname, forKey: UserDefaultKeys.User.username.rawValue)
                     await send(.delegate(.didCompleteSignup(nickname: nickname)))
                 }
                 
             case .nickNameError:
-                
+                state.nicknameState = .error(message: .duplication)
+                state.isButtonEnabled = false
                 return .none
                 
             case .birhDayError:
                 state.birthdayState = .error(message: .condition(type: .birthday))
+                state.isButtonEnabled = false
+                return .none
                 
+            case .dismissAlert:
+                state.signupErrorAlert = nil
                 return .none
                 
             case .binding(_):

--- a/Soongan/Feature/AuthFeature/Sources/View/LoginView.swift
+++ b/Soongan/Feature/AuthFeature/Sources/View/LoginView.swift
@@ -106,6 +106,17 @@ public struct LoginView: View {
             .onAppear {
                 store.send(.onAppear)
             }
+            .fullScreenCover(item: $store.loginErrorAlert) { alertType in
+                CustomAlertView<LoginErrorType>(
+                    type: alertType,
+                    centerButtonAction: {
+                        store.send(.dismissAlert)
+                    }
+                ).presentationBackground(.clear)
+            }
+            .transaction { transaction in
+                transaction.disablesAnimations = true
+            }
         } destination: { store in
             switch store.case {
             case .signup(let store):

--- a/Soongan/Feature/AuthFeature/Sources/View/SignupView.swift
+++ b/Soongan/Feature/AuthFeature/Sources/View/SignupView.swift
@@ -86,6 +86,7 @@ public struct SignupView: View {
             isNicknameFieldFocused = true
         }
         .navigationBarBackButtonHidden(true)
+        .background(alertHostingView)
         .toolbar {
             ToolbarItem(placement: .navigationBarLeading) {
                 Button {
@@ -102,6 +103,21 @@ public struct SignupView: View {
                 }
                 .padding(.top, 16)
             }
+        }
+    }
+    
+    @ViewBuilder
+    var alertHostingView: some View {
+        Color.clear .fullScreenCover(item: $store.signupErrorAlert) { alertType in
+            CustomAlertView<SignupErrorType>(
+                type: alertType,
+                centerButtonAction: {
+                    store.send(.dismissAlert)
+                }
+            ).presentationBackground(.clear)
+        }
+        .transaction { transaction in
+            transaction.disablesAnimations = true
         }
     }
 }

--- a/Soongan/Feature/ContestFeature/Sources/Logic/ContestFeature.swift
+++ b/Soongan/Feature/ContestFeature/Sources/Logic/ContestFeature.swift
@@ -35,6 +35,8 @@ public struct ContestFeature {
     public struct State: Equatable {
         var path = StackState<ContestPath.State>()
         
+        var reportHistories = [Int]()
+        var allPosts = [ContestImageModel]()
         var contestOptions = [ContestIndexModel]()
         var scrollPosition: ScrollPosition = ScrollPosition(idType: ContestImageModel.ID.self)
         
@@ -101,6 +103,7 @@ public struct ContestFeature {
             case loadMoreContestsPosts
             case updateContestPageInfo(PageInfoData)
             case refreshTriggered
+            case getMyProfileSuccess(SearchMyProfileResponseDTO)
         }
         
         public enum UIAction {
@@ -136,13 +139,23 @@ public struct ContestFeature {
             switch action {
             case .onAppear:
                 return .run { send in
-                    let result: Result<SearchContestListResponseDTO, NetworkError> = await NetworkManager.shared.request(WeeklyContestEndpoint.getContestList)
-                    
-                    switch result {
+                    async let contestListResult: Result<SearchContestListResponseDTO, NetworkError> = NetworkManager.shared.request(WeeklyContestEndpoint.getContestList)
+                    async let myProfileResult: Result<SearchMyProfileResponseDTO, NetworkError> = NetworkManager.shared.request(MemberEndpoint.getMembers)
+
+                    let (contestResponse, myProfileResponse) = await (contestListResult, myProfileResult)
+
+                    switch contestResponse {
                     case .success(let response):
                         await send(.networkAction(.getContestListSuccess(response)))
                     case .failure(let error):
-                        print(error.localizedDescription)
+                        print(error.localizedDescription) // TODO: Error Handling
+                    }
+
+                    switch myProfileResponse {
+                    case .success(let response):
+                        await send(.networkAction(.getMyProfileSuccess(response)))
+                    case .failure(let error):
+                        print(error.localizedDescription) // TODO: Error Handling
                     }
                 }
               
@@ -218,45 +231,50 @@ public struct ContestFeature {
                     }
                 }
                 
-            // 게시물 데이터를 성공적으로 받으면 상태를 업데이트합니다.
             case .networkAction(.getContestSuccess(let response)):
+                // 페이지 정보 업데이트
                 state.contestIndex = response.round
                 state.weekTopic = response.subject
-                
                 state.currentPageNum = response.pageInfo.page
                 state.hasNextPage = response.pageInfo.hasNext
-                
+
+                // 첫 페이지거나 새로고침이면 마스터 리스트를 비웁니다.
                 if state.currentPageNum == 0 {
-                    state.leftContestImageList.removeAll()
-                    state.rightContestImageList.removeAll()
+                    state.allPosts.removeAll()
                 }
+
+                // 신고된 게시물을 필터링하고, 마스터 리스트에 새로운 게시물을 추가
+                let reportedIDs = Set(state.reportHistories)
+                let newPosts = response.posts
+                    .filter { !reportedIDs.contains($0.postId) }
+                    .map { ContestImageModel(id: $0.postId, imageUrl: $0.imageUrl, nickname: $0.nickname) }
                 
-                let totalCount = state.leftContestImageList.count + state.rightContestImageList.count
-                
-                var tempLeftConestImageData = [ContestImageModel]()
-                var tempRightConestImageData = [ContestImageModel]()
-                
-                for (index, item) in response.posts.enumerated() {
-                    let model = ContestImageModel(id: item.postId, imageUrl: item.imageUrl, nickname: item.nickname)
-                    
-                    if (totalCount + index) % 2 == 0 {
-                        tempLeftConestImageData.append(model)
+                state.allPosts.append(contentsOf: newPosts)
+
+                // 임시 배열을 사용하여 마스터 리스트를 기준으로 두 개의 컬럼 리스트를 새로 만듦
+                var tempLeftList = [ContestImageModel]()
+                var tempRightList = [ContestImageModel]()
+                for (index, post) in state.allPosts.enumerated() {
+                    if index % 2 == 0 {
+                        tempLeftList.append(post)
                     } else {
-                        tempRightConestImageData.append(model)
+                        tempRightList.append(post)
                     }
                 }
                 
-                state.leftContestImageList += tempLeftConestImageData
-                state.rightContestImageList += tempRightConestImageData
-                
-                state.hasNextPage = response.pageInfo.hasNext
-                state.weekTopic = response.subject
+                // 마지막에 한 번만 상태를 업데이트하여 View 리렌더링을 최소화
+                state.leftContestImageList = tempLeftList
+                state.rightContestImageList = tempRightList
                 
                 return .run { send in
                     try await Task.sleep(for: .seconds(0.7))
                     await send(.view(.hideInitialLoading))
                 }
-
+                
+            case .networkAction(.getMyProfileSuccess(let response)):
+                state.reportHistories = response.reportHistories.compactMap { $0?.targetId }
+                
+                return .none
                 
             case let .path(.element(id: _, action: action)):
                 switch action {
@@ -277,6 +295,28 @@ public struct ContestFeature {
                     )
                     state.path.append(.editPost(editState))
                     return .none
+                    
+                case .contestDetail(.delegate(.reportCompleted(let postId))):
+                    state.path.removeLast()
+                    state.reportHistories.append(postId)
+                    state.allPosts.removeAll { $0.id == postId }
+
+                    // 임시 배열을 사용하여 마스터 리스트를 기준으로 두 개의 컬럼 리스트를 새로 만듦
+                    var tempLeftList = [ContestImageModel]()
+                    var tempRightList = [ContestImageModel]()
+                    for (index, post) in state.allPosts.enumerated() {
+                        if index % 2 == 0 {
+                            tempLeftList.append(post)
+                        } else {
+                            tempRightList.append(post)
+                        }
+                    }
+                    
+                    // 마지막에 한 번만 상태를 업데이트하여 View 리렌더링을 최소화
+                    state.leftContestImageList = tempLeftList
+                    state.rightContestImageList = tempRightList
+                    return .none
+                    
                 case .editPost(.delegate(.editCompleted)):
                     state.path.removeLast()
                     return .send(.networkAction(.refreshTriggered)) // 수정 완료 후 새로고침

--- a/Soongan/Feature/ContestFeature/Sources/Logic/ContestFeature.swift
+++ b/Soongan/Feature/ContestFeature/Sources/Logic/ContestFeature.swift
@@ -251,16 +251,7 @@ public struct ContestFeature {
                 
                 state.allPosts.append(contentsOf: newPosts)
 
-                // 임시 배열을 사용하여 마스터 리스트를 기준으로 두 개의 컬럼 리스트를 새로 만듦
-                var tempLeftList = [ContestImageModel]()
-                var tempRightList = [ContestImageModel]()
-                for (index, post) in state.allPosts.enumerated() {
-                    if index % 2 == 0 {
-                        tempLeftList.append(post)
-                    } else {
-                        tempRightList.append(post)
-                    }
-                }
+                let (tempLeftList, tempRightList) = rebuildColumnLists(from: state.allPosts)
                 
                 // 마지막에 한 번만 상태를 업데이트하여 View 리렌더링을 최소화
                 state.leftContestImageList = tempLeftList
@@ -302,15 +293,7 @@ public struct ContestFeature {
                     state.allPosts.removeAll { $0.id == postId }
 
                     // 임시 배열을 사용하여 마스터 리스트를 기준으로 두 개의 컬럼 리스트를 새로 만듦
-                    var tempLeftList = [ContestImageModel]()
-                    var tempRightList = [ContestImageModel]()
-                    for (index, post) in state.allPosts.enumerated() {
-                        if index % 2 == 0 {
-                            tempLeftList.append(post)
-                        } else {
-                            tempRightList.append(post)
-                        }
-                    }
+                    let (tempLeftList, tempRightList) = rebuildColumnLists(from: state.allPosts)
                     
                     // 마지막에 한 번만 상태를 업데이트하여 View 리렌더링을 최소화
                     state.leftContestImageList = tempLeftList
@@ -425,5 +408,21 @@ public struct ContestFeature {
             }
         }
         .forEach(\.path, action: \.path)
+    }
+}
+
+
+private extension ContestFeature {
+    func rebuildColumnLists(from allPosts: [ContestImageModel]) -> (left: [ContestImageModel], right: [ContestImageModel]) {
+        var tempLeftList = [ContestImageModel]()
+        var tempRightList = [ContestImageModel]()
+        for (index, post) in allPosts.enumerated() {
+            if index % 2 == 0 {
+                tempLeftList.append(post)
+            } else {
+                tempRightList.append(post)
+            }
+        }
+        return (tempLeftList, tempRightList)
     }
 }

--- a/Soongan/Feature/DetailContestFeature/Sources/Logic/ContestDetailFeature.swift
+++ b/Soongan/Feature/DetailContestFeature/Sources/Logic/ContestDetailFeature.swift
@@ -34,6 +34,7 @@ public struct ContestDetailFeature {
         var contestAuthor: String?
         var isLiked: Bool?
         var likeCount: String?
+        var isTop7: Bool?
         
         var reportReason: String?
         
@@ -108,6 +109,7 @@ public struct ContestDetailFeature {
             case backConfirmed
             case didRequestLogout
             case editRequested(contestId: Int, round: Int, title: String, imageURL: String, weekTopic: String)
+            case reportCompleted(postId: Int)
         }
     }
     
@@ -117,6 +119,9 @@ public struct ContestDetailFeature {
         case dismissAlertButtonTapped
         case dismissLoginAlert
         case dismissAlert
+        
+        case presentEditTop7Alert
+        case presentDeleteTop7Alert
     }
     
     public enum SheetAction {
@@ -126,6 +131,7 @@ public struct ContestDetailFeature {
         case editButtonTapped
         case deleteOptionButtonTapped
         case reportSheetIsPresented
+        case completeReportButtonTapped
     }
     
     public enum NetworkAction {
@@ -175,6 +181,7 @@ public struct ContestDetailFeature {
                 state.postUserId = response.authorMemberId
                 state.postRound = response.weeklyContestRound
                 state.weekTopic = response.weeklyContestSubject
+                state.isTop7 = response.isTop7
                 state.contestTitle = response.title
                 state.contestAuthor = response.nickname
                 state.imageUrl = response.imageUrl
@@ -278,19 +285,40 @@ public struct ContestDetailFeature {
             case .networkAction(.likeContestFailure(let error)):
                 // TODO: - 좋아요 에러
                 return .none
-                
+              
+            /// 게시글 옵션 Sheet 에서 수정하기 버튼을 눌렀을때
             case .sheetAction(.editButtonTapped):
-                state.pendingSheetAction = .edit
+                guard let isTop7 = state.isTop7 else { return .none }
+                
                 state.isContestOptionSheetPresented = false
                 
-                return .none
+                if isTop7 {
+                    return .run { send in
+                        try await Task.sleep(nanoseconds: 300_000_000)
+                        await send(.alertAction(.presentEditTop7Alert))
+                    }
+                } else {
+                    state.pendingSheetAction = .edit
+                    return .none
+                }
             
+            /// 게시글 옵션 Sheet 에서 삭제하기 버튼을 눌렀을때
             case .sheetAction(.deleteOptionButtonTapped):
-                state.pendingSheetAction = .delete
-                state.isContestOptionSheetPresented = false
-
-                return .none
+                guard let isTop7 = state.isTop7 else { return .none }
                 
+                state.isContestOptionSheetPresented = false
+                
+                if isTop7 {
+                    return .run { send in
+                        try await Task.sleep(nanoseconds: 300_000_000)
+                        await send(.alertAction(.presentDeleteTop7Alert))
+                    }
+                } else {
+                    state.pendingSheetAction = .delete
+                    return .none
+                }
+                
+            /// 게시글 옵션 Sheet 에서 신고하기 버튼을 눌렀을때
             case .sheetAction(.reportSheetIsPresented):
                 state.pendingSheetAction = .report
                 state.isContestOptionSheetPresented = false
@@ -408,6 +436,18 @@ public struct ContestDetailFeature {
                       break
                   }
                 
+                return .none
+            
+            case .sheetAction(.completeReportButtonTapped):
+                state.completeReportSheet = nil
+                return .none
+                
+            case .alertAction(.presentEditTop7Alert):
+                state.alertSheet = .editContainPostToTop7
+                return .none
+                
+            case .alertAction(.presentDeleteTop7Alert):
+                state.alertSheet = .deleteContainPostToTop7
                 return .none
                 
             case .alertAction(.notAuthUserAlert):

--- a/Soongan/Feature/DetailContestFeature/Sources/View/ContestDetailView.swift
+++ b/Soongan/Feature/DetailContestFeature/Sources/View/ContestDetailView.swift
@@ -35,7 +35,7 @@ public struct ContestDetailView: View {
             .background(InteractivePopGestureEnabler())
             .fullScreenCover(item: $store.alertSheet) { alertType in
                 if alertType == .deletePost {
-                    CustomAlertView(
+                    CustomAlertView<AlertType>(
                         type: alertType,
                         leftButtonAction: {
                             store.send(.alertAction(.dismissAlert))
@@ -47,10 +47,28 @@ public struct ContestDetailView: View {
                 }
                 
                 if alertType == .deletePostComplete {
-                    CustomAlertView(
+                    CustomAlertView<AlertType>(
                         type: alertType,
                         centerButtonAction: {
                             store.send(.deleteCompletedButtonTapped)
+                        }
+                    ).presentationBackground(.clear)
+                }
+                
+                if alertType == .deleteContainPostToTop7 {
+                    CustomAlertView<AlertType>(
+                        type: alertType,
+                        centerButtonAction: {
+                            store.send(.alertAction(.dismissAlert))
+                        }
+                    ).presentationBackground(.clear)
+                }
+                
+                if alertType == .editContainPostToTop7 {
+                    CustomAlertView<AlertType>(
+                        type: alertType,
+                        centerButtonAction: {
+                            store.send(.alertAction(.dismissAlert))
                         }
                     ).presentationBackground(.clear)
                 }
@@ -94,8 +112,14 @@ public struct ContestDetailView: View {
                     store.send(.sheetAction(.reportReasonButtonTapped(type: reportType, reason: reasonText)))
                 }
             }
-            .sheet(item : $store.completeReportSheet) { sheetType in
-                CustomSheetView<ContestReportReasonType>(type: sheetType) { _ in }
+            .sheet(item: $store.completeReportSheet, onDismiss: {
+                if store.completeReportSheet == nil {
+                    store.send(.delegate(.reportCompleted(postId: store.postId)))
+                }
+            }) { sheetType in
+                CustomSheetView<ContestReportReasonType>(type: sheetType) { _ in
+                    store.send(.sheetAction(.completeReportButtonTapped))
+                }
             }
             .fullScreenCover(
                 isPresented: $store.isFullSizeImageSheetPresented.sending(\.dismissFullSizeImageSheet)
@@ -202,7 +226,7 @@ public struct ContestDetailView: View {
     @ViewBuilder
     var alertHostingView: some View {
         Color.clear.fullScreenCover(isPresented: $store.isLoginAlertPresented) {
-            CustomAlertView(
+            CustomAlertView<AlertType>(
                 type: .showLoginView,
                 onBackgroundTap: {
                     store.send(.alertAction(.dismissLoginAlert))

--- a/Soongan/Feature/HomeFeature/Sources/View/HomeView.swift
+++ b/Soongan/Feature/HomeFeature/Sources/View/HomeView.swift
@@ -313,7 +313,7 @@ private extension HomeView {
     @ViewBuilder
     var alertHostingView: some View {
         Color.clear.fullScreenCover(isPresented: $store.isAlertPresented) {
-            CustomAlertView(
+            CustomAlertView<AlertType>(
                 type: .showLoginView,
                 onBackgroundTap: {
                     store.send(.alertAction(.dismissLoginAlert))

--- a/Soongan/Feature/MypageFeature/Sources/View/MypageView.swift
+++ b/Soongan/Feature/MypageFeature/Sources/View/MypageView.swift
@@ -229,7 +229,7 @@ private extension MypageView {
     @ViewBuilder
     var alertHostingView: some View {
         Color.clear.fullScreenCover(isPresented: $store.isLoginAlertPresented) {
-            CustomAlertView(
+            CustomAlertView<AlertType>(
                 type: .showLoginView,
                 onBackgroundTap: {
                     store.send(.dismissLoginAlert)

--- a/Soongan/Feature/PostPictureFeature/Sources/View/PostPictureView.swift
+++ b/Soongan/Feature/PostPictureFeature/Sources/View/PostPictureView.swift
@@ -131,7 +131,7 @@ public struct PostPictureView: View {
             if let type = store.alertPresentedType {
                 switch type {
                 case .backPostContest, .backEditContest:
-                    CustomAlertView(
+                    CustomAlertView<AlertType>(
                         type: type,
                         leftButtonAction: {
                             store.send(.dismissAlertButtonTapped)
@@ -144,7 +144,7 @@ public struct PostPictureView: View {
                     .presentationBackground(.clear)
                     
                 case .postContestError:
-                    CustomAlertView(
+                    CustomAlertView<AlertType>(
                         type: type,
                         centerButtonAction: {
                             store.send(.dismissAlertButtonTapped)
@@ -154,7 +154,7 @@ public struct PostPictureView: View {
                     .presentationBackground(.clear)
                     
                 case .showLoginView:
-                    CustomAlertView(
+                    CustomAlertView<AlertType>(
                         type: type,
                         centerButtonAction: {
                             store.send(.dismissAlertButtonTapped)

--- a/Soongan/Feature/SplashFeature/Sources/View/SplashView.swift
+++ b/Soongan/Feature/SplashFeature/Sources/View/SplashView.swift
@@ -54,7 +54,7 @@ public struct SplashView: View {
             store.send(.onAppear)
         }
         .fullScreenCover(isPresented: $store.isUpdateAlertPresented) {
-            CustomAlertView(
+            CustomAlertView<AlertType>(
                 type: .forceUpdate,
                 centerButtonAction: {
                     store.send(.updateButtonTapped)

--- a/Soongan/Project.swift
+++ b/Soongan/Project.swift
@@ -5,7 +5,7 @@ import ProjectDescription
 let projectSettings: Settings = .settings(
     base: [
         "MARKETING_VERSION": "1.0.0",
-        "CURRENT_PROJECT_VERSION": "1",
+        "CURRENT_PROJECT_VERSION": "3",
         "DEVELOPMENT_TEAM": "9QK3G4VF9N",
         "OTHER_LDFLAGS": ["-all_load"]
     ],
@@ -33,6 +33,7 @@ let project = Project(
             deploymentTargets: .iOS("18.0"),
             infoPlist: .extendingDefault(
                 with: [
+                    "UIUserInterfaceStyle": "Light",
                     "UILaunchScreen": [
                         "UIColorName": "",
                         "UIImageName": "",

--- a/Soongan/Shared/Sources/Extension/String+.swift
+++ b/Soongan/Shared/Sources/Extension/String+.swift
@@ -21,7 +21,14 @@ public extension String {
         if self.isEmpty {
             return .empty
         }
-
+        
+        // 특수문자가 존재하는 경우
+        let regex = "^[가-힣a-zA-Z0-9]+$"
+        let predicate = NSPredicate(format: "SELF MATCHES %@", regex)
+        if !predicate.evaluate(with: self) {
+            return .invalidCharacters
+        }
+        
         if self.count < 3 {
             return .tooShort
         }
@@ -36,12 +43,12 @@ public extension String {
             return .onlyConsonantsOrVowels
         }
 
-        // 특수문자가 존재하는 경우
-        let regex = "^[가-힣a-zA-Z0-9]+$"
-        let predicate = NSPredicate(format: "SELF MATCHES %@", regex)
-        if !predicate.evaluate(with: self) {
-            return .invalidCharacters
-        }
+//        // 특수문자가 존재하는 경우
+//        let regex = "^[가-힣a-zA-Z0-9]+$"
+//        let predicate = NSPredicate(format: "SELF MATCHES %@", regex)
+//        if !predicate.evaluate(with: self) {
+//            return .invalidCharacters
+//        }
 
         return .valid
     }

--- a/Soongan/Shared/Sources/Extension/String+.swift
+++ b/Soongan/Shared/Sources/Extension/String+.swift
@@ -42,14 +42,7 @@ public extension String {
         if self.contains(where: { disallowedCharacters.contains($0) }) {
             return .onlyConsonantsOrVowels
         }
-
-//        // 특수문자가 존재하는 경우
-//        let regex = "^[가-힣a-zA-Z0-9]+$"
-//        let predicate = NSPredicate(format: "SELF MATCHES %@", regex)
-//        if !predicate.evaluate(with: self) {
-//            return .invalidCharacters
-//        }
-
+        
         return .valid
     }
     


### PR DESCRIPTION
## 📟 관련 이슈
- Resolved: #43 

<br>

## 👷 작업한 내용
<!-- 작업한 내용을 적어주세요. -->
- 소셜 로그인 및 에러 처리 시스템 리팩토링
- 재사용성을 고려한 `CustomAlertView` 제네릭화
- 신고한 게시물 숨기기 및 TOP 7 게시물 보호 기능 추가
- 프로젝트 버전 업데이트 및 기타 수정

<br>

## 📸 스크린샷
|기능|삭제한 게시글 숨기기|
|:--:|:--:|
|GIF|<img src = "https://github.com/user-attachments/assets/677322ee-93ef-4a24-a4a4-9a08978e7606" width ="250">|

<br>

## 🚨 참고 사항
<!-- 참고 사항을 적어주세요. 없으면 지워주세요. -->

### 1. 소셜 로그인 및 에러 처리 시스템 리팩토링

#### AS-IS (문제점)
- 기존 로그인 로직은 `.loginSuccess`, `.loginFailure` 등 단편적인 액션으로만 관리되어, 어느 단계에서 실패했는지 파악하기 어려웠습니다.
- `AppleLoginService` 에서 `Continuation` 을 사용한 후 `nil` 로 초기화하지 않아, 잠재적인 메모리 누수 및 크래시 위험이 있었습니다.

#### TO-BE (개선 내용)
- 로그인 과정을 소셜 로그인 → 서버 인증 → 프로필 조회의 명확한 단계로 나누고, 각 단계별 성공/실패 액션을 새로 정의하여 흐름을 명확하게 만들었습니다.
- `AppleLoginService` 의 델리게이트 메서드에서 `continuation = nil` 을 명시하여 잠재적 크래시를 방지했습니다.

<br>

### 2. 재사용성을 고려한 CustomAlertView 제네릭화

#### AS-IS (문제점)
- `CustomAlertView` 가 모든 종류의 `Alert` 을 처리하는 거대한 `AlertType` 열거형에만 의존하고 있었습니다.
- 새로운 종류의 `Alert` 을 추가하려면 거대한 `AlertType` 을 계속 수정해야 했고 특정 `View` 에서는 사용하지도 않는 수많은 `case` 들을 알아야 하는 불편함이 있었습니다.

#### TO-BE (개선 내용)
- `Alert` 이 가져야 할 최소한의 요소를 정의하는 `AlertDisplayable` 프로토콜을 도입했습니다.

``` swift
public protocol AlertDisplayable: Identifiable {
    var title: String { get }
    var centerButtonTitle: String { get }
}

public struct CustomAlertView<T: AlertDisplayable>: View { ... }
```

- 이를 통해 `LoginFeature` 에서는 `LoginErrorType` 을, `SignupFeature` 에서는 `SignupErrorType` 을 각각 정의하여 `CustomAlertView` 에 넘겨줄 수 있게 되었습니다. 이제 자신이 책임져야 할 `Alert` 만 신경 쓰면 되므로 코드의 확장성과 유지보수성이 크게 향상되었습니다.

<br>

### 3. ContestFeature 상태 관리 리팩토링 및 기능 추가

#### AS-IS (문제점)
- 게시물 목록을 `leftContestImageList` 와 `rightContestImageList` 두 개의 배열로 나누어 관리했습니다.
- 이 구조에서는 아이템 하나가 삭제될 경우 한쪽 컬럼만 줄어들어 양쪽의 균형이 깨지고 UI가 어색하게 변하는 문제가 있었습니다.

#### TO-BE (개선 내용)
- 모든 게시물을 담는 `allPosts` 배열을 `State` 의 단일 원본으로 사용하도록 구조를 변경했습니다.
- 이제 데이터가 추가되거나(`getContestSuccess`), 삭제될 때(`reportCompleted` delegate), `allPosts` 배열을 먼저 수정한 뒤, 이 배열을 기준으로 left/right 리스트를 처음부터 다시 생성합니다.

<br>

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
