### PR TITLE
[Fix] #45 - 프로필 편집 관련 검증 로직 개선

### DIFF
--- a/Soongan/DesignSystem/Sources/Component/CustomTextFieldView.swift
+++ b/Soongan/DesignSystem/Sources/Component/CustomTextFieldView.swift
@@ -57,6 +57,7 @@ public struct CustomTextFieldView: View {
                 .focused(isFocused)
                 .font(DesignSystem.Font.regular18)
                 .padding()
+                .padding(.trailing, 35)
                 .tint(.black100)
                 .background(
                     backgroundShape
@@ -68,25 +69,21 @@ public struct CustomTextFieldView: View {
                 .foregroundColor(.black100)
                 .overlay(
                     Group {
-                        Button(action: {
+                        switch state {
+                        case .normal:
+                            Image.checkCircle
                             
-                        }) {
-                            switch state {
-                            case .normal:
-                                Image.checkCircle
-                                
-                            case .possible:
-                                Image.completeCheckCircle
-                                
-                            case .valid:
-                                Image.checkCircle
-                                
-                            case .error:
-                                Image.errorDeleteCircle
-                            }
+                        case .possible:
+                            Image.completeCheckCircle
+                            
+                        case .valid:
+                            Image.checkCircle
+                            
+                        case .error:
+                            Image.errorDeleteCircle
                         }
-                        .padding(.trailing, 12)
-                    },
+                    }
+                    .padding(.trailing, 12),
                     alignment: .trailing
                 )
             

--- a/Soongan/Feature/MypageFeature/Sources/Logic/EditProfileFeature.swift
+++ b/Soongan/Feature/MypageFeature/Sources/Logic/EditProfileFeature.swift
@@ -221,11 +221,8 @@ private extension EditProfileFeature {
         if state.introduce.count > 25 {
             state.introduceState = .normal
             state.isIntroduceButtonEnabled = false
-        } else if state.introduce.count > 0 && state.introduce.count <= 25 {
-            state.introduceState = .possible
-            state.isIntroduceButtonEnabled = true
         } else {
-            state.introduceState = .normal
+            state.introduceState = .possible
             state.isIntroduceButtonEnabled = true
         }
     }

--- a/Soongan/Feature/MypageFeature/Sources/Logic/EditProfileFeature.swift
+++ b/Soongan/Feature/MypageFeature/Sources/Logic/EditProfileFeature.swift
@@ -179,7 +179,7 @@ public struct EditProfileFeature {
                 return .none
                 
             case .isEditButtonEnabledChanged:
-                state.editButtonState = state.isNicknameButtonEnabled
+                state.editButtonState = state.isNicknameButtonEnabled && state.isIntroduceButtonEnabled
                 
                 return .none
                 
@@ -218,12 +218,15 @@ private extension EditProfileFeature {
     }
 
     func validateIntroduce(state: inout State) {
-        if state.introduce.count > 0 && state.introduce.count <= 25 {
+        if state.introduce.count > 25 {
+            state.introduceState = .normal
+            state.isIntroduceButtonEnabled = false
+        } else if state.introduce.count > 0 && state.introduce.count <= 25 {
             state.introduceState = .possible
             state.isIntroduceButtonEnabled = true
         } else {
             state.introduceState = .normal
-            state.isIntroduceButtonEnabled = false
+            state.isIntroduceButtonEnabled = true
         }
     }
 }

--- a/Soongan/Feature/MypageFeature/Sources/Logic/EditProfileFeature.swift
+++ b/Soongan/Feature/MypageFeature/Sources/Logic/EditProfileFeature.swift
@@ -85,7 +85,10 @@ public struct EditProfileFeature {
                     state.introduce = introduce
                 }
                 
-                return .none
+                validateNickname(state: &state)
+                validateIntroduce(state: &state)
+                
+                return .send(.isEditButtonEnabledChanged)
                 
             case .editMyProfileButtonTapped:
                 let dto = EditMyProfileRequestDTO(
@@ -134,35 +137,11 @@ public struct EditProfileFeature {
                 return .none
                 
             case .binding(\.nickname):
-                switch state.nickname.nicknameValidationState {
-                case .empty, .tooShort, .tooLong:
-                    state.nicknameState = .normal
-                    state.isNicknameButtonEnabled = false
-                    
-                case .invalidCharacters:
-                    state.nicknameState = .error(message: .specialCharacter)
-                    state.isNicknameButtonEnabled = false
-                    
-                case .valid:
-                    state.nicknameState = .possible
-                    state.isNicknameButtonEnabled = true
-                    
-                case .onlyConsonantsOrVowels:
-                    state.nicknameState = .error(message: .onlyConsonantsOrVowels)
-                    state.isNicknameButtonEnabled = false
-                }
-                
+                validateNickname(state: &state)
                 return .send(.isEditButtonEnabledChanged)
                 
             case .binding(\.introduce):
-                if state.introduce.count > 0 && state.introduce.count <= 25 {
-                    state.introduceState = .possible
-                    state.isIntroduceButtonEnabled = true
-                } else {
-                    state.introduceState = .normal
-                    state.isIntroduceButtonEnabled = false
-                }
-                
+                validateIntroduce(state: &state)
                 return .send(.isEditButtonEnabledChanged)
                 
             case .binding(\.selectedItem):
@@ -200,7 +179,7 @@ public struct EditProfileFeature {
                 return .none
                 
             case .isEditButtonEnabledChanged:
-                state.editButtonState = state.isNicknameButtonEnabled && state.isIntroduceButtonEnabled
+                state.editButtonState = state.isNicknameButtonEnabled
                 
                 return .none
                 
@@ -211,6 +190,40 @@ public struct EditProfileFeature {
             default:
                 return .none
             }
+        }
+    }
+}
+
+// MARK: - Private func Extension
+
+private extension EditProfileFeature {
+    func validateNickname(state: inout State) {
+        switch state.nickname.nicknameValidationState {
+        case .empty, .tooShort, .tooLong:
+            state.nicknameState = .normal
+            state.isNicknameButtonEnabled = false
+            
+        case .invalidCharacters:
+            state.nicknameState = .error(message: .specialCharacter)
+            state.isNicknameButtonEnabled = false
+            
+        case .valid:
+            state.nicknameState = .possible
+            state.isNicknameButtonEnabled = true
+            
+        case .onlyConsonantsOrVowels:
+            state.nicknameState = .error(message: .onlyConsonantsOrVowels)
+            state.isNicknameButtonEnabled = false
+        }
+    }
+
+    func validateIntroduce(state: inout State) {
+        if state.introduce.count > 0 && state.introduce.count <= 25 {
+            state.introduceState = .possible
+            state.isIntroduceButtonEnabled = true
+        } else {
+            state.introduceState = .normal
+            state.isIntroduceButtonEnabled = false
         }
     }
 }


### PR DESCRIPTION
## 📟 관련 이슈
- Resolved: #45

<br>

## 👷 작업한 내용
<!-- 작업한 내용을 적어주세요. -->
- 프로필 수정 시 닉네임과 소개글 25자 제한 검증 로직 개선 
- TextField UI에서 아이콘 위치 조정 및 텍스트 영역 제한
- 소개글이 비어있어도 수정 가능하도록 유효성 검증 수정

<br>

## 🚨 참고 사항
<!-- 참고 사항을 적어주세요. 없으면 지워주세요. -->

### 1. `EditProfileFeature` 변경사항
- 닉네임과 소개글 유효성 검증 함수를 별도 메서드로 분리
- 소개글 25자 초과 시 수정 버튼 비활성화
- 수정 버튼 활성화 조건을 닉네임과 소개글 유효성 모두 확인하도록 변경
- 앱 시작 시 유효성 검증 로직 추가

### 2. `CustomTextFieldView` 변경사항
- `overlay` 아이콘을 오른쪽에서 12dp 떨어진 위치로 조정
- `TextField` 텍스트가 아이콘 영역에 침범하지 않도록 trailing padding 추가
- Button에서 Image로 변경하여 UI 간소화

<br>

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
