### PR TITLE
[Refactor] #48 - iOS 26 리퀴드 글래스 대응 관련 UI 수정

### DIFF
--- a/Soongan/DesignSystem/Sources/Component/CustomNavigationBarView.swift
+++ b/Soongan/DesignSystem/Sources/Component/CustomNavigationBarView.swift
@@ -64,7 +64,7 @@ public struct CustomNavigationBarView: View {
                 if let titleFont = navigationCase.titleFont {
                     Text(titleString)
                         .font(titleFont, lineHeight: 20)
-                        .foregroundColor(DesignSystem.Color.black100)
+                        .foregroundStyle(DesignSystem.Color.black100)
                 }
                 
             case .backButton, .signup:

--- a/Soongan/DesignSystem/Sources/Component/CustomNavigationBarView.swift
+++ b/Soongan/DesignSystem/Sources/Component/CustomNavigationBarView.swift
@@ -1,0 +1,89 @@
+//
+//  CustomNavigationBarView.swift
+//  DesignSystem
+//
+//  Created by ParkJunHyuk on 11/5/25.
+//
+
+import SwiftUI
+
+public struct CustomNavigationBarView: View {
+    
+    // MARK: - Properties
+    
+    private let navigationCase: NavigationCase
+    private let backAction: () -> Void
+    
+    // MARK: - Init
+    
+    public init(
+        navigationCase: NavigationCase,
+        backAction: @escaping () -> Void
+    ) {
+        self.navigationCase = navigationCase
+        self.backAction = backAction
+    }
+    
+    // MARK: - Body
+    
+    public var body: some View {
+        ZStack {
+            // 배경과 뒤로가기 버튼
+            HStack {
+                Button(action: backAction) {
+                    HStack(spacing: 0) {
+                        Image.arrowBack
+                        
+                        if case .signup = navigationCase {
+                            Text("회원가입")
+                                .font(DesignSystem.Font.medium24, lineHeight: 32)
+                                .foregroundStyle(DesignSystem.Color.black100)
+                        }
+                    }
+                }
+                .padding(.leading, 20)
+                
+                Spacer()
+            }
+            
+            // 중앙에 위치한 타이틀
+            switch navigationCase {
+            case .postImage(let round, let weekTopic):
+                HStack(spacing: 8) {
+                    Text("\(round)회차")
+                    
+                    Text("|")
+                        .font(DesignSystem.Font.medium20)
+                    
+                    Text(weekTopic)
+                }
+                .font(DesignSystem.Font.bold20, lineHeight: 20)
+                .foregroundStyle(DesignSystem.Color.black100)
+                
+            case .title(let titleString):
+                if let titleFont = navigationCase.titleFont {
+                    Text(titleString)
+                        .font(titleFont, lineHeight: 20)
+                        .foregroundColor(DesignSystem.Color.black100)
+                }
+                
+            case .backButton, .signup:
+                EmptyView()
+            }
+        }
+        .frame(height: 54)
+        .background(DesignSystem.Color.soonganBG)
+    }
+}
+
+//#Preview {
+//    VStack(spacing: 20) {
+//        CustomNavigationBarView(title: "프로필 수정") {
+//            print("Back button tapped")
+//        }
+//        
+//        CustomNavigationBarView(title: nil) {
+//            print("Back button tapped")
+//        }
+//    }
+//}

--- a/Soongan/DesignSystem/Sources/Enum/NavigationCase.swift
+++ b/Soongan/DesignSystem/Sources/Enum/NavigationCase.swift
@@ -1,0 +1,28 @@
+//
+//  NavigationCase.swift
+//  DesignSystem
+//
+//  Created by ParkJunHyuk on 11/6/25.
+//
+
+import Foundation
+
+public enum NavigationCase {
+    case postImage(round: Int, weekTopic: String)
+    case title(String)
+    case backButton
+    case signup
+    
+    var titleFont: FontStyle? {
+        switch self {
+        case .postImage:
+            return DesignSystem.Font.bold20
+        case .title:
+            return DesignSystem.Font.bold16
+        case .backButton:
+            return nil
+        case .signup:
+            return DesignSystem.Font.medium24
+        }
+    }
+}

--- a/Soongan/Feature/AuthFeature/Sources/View/SignupView.swift
+++ b/Soongan/Feature/AuthFeature/Sources/View/SignupView.swift
@@ -31,55 +31,61 @@ public struct SignupView: View {
     
     public var body: some View {
         ZStack {
-            Color.clear
-                .contentShape(Rectangle())
+            DesignSystem.Color.soonganBG
+                .ignoresSafeArea()
                 .onTapGesture {
                     UIApplication.shared.dismissKeyboard()
                 }
             
             VStack(spacing: 0) {
-                Spacer()
-                
-                CustomTextFieldView(
-                    type: .nickname,
-                    text: $store.nickname,
-                    isFocused: $isNicknameFieldFocused,
-                    state: $store.nicknameState
-                )
-                .offset(y: store.signupState == .inputBirthday ? -20 : 0)
-                .animation(.easeInOut, value: store.signupState)
-                
-                if store.signupState == .inputBirthday {
-                    CustomTextFieldView(
-                        type: .birthday,
-                        text: $store.birthday,
-                        isFocused: $isBirthdayFocused,
-                        state: $store.birthdayState
-                    )
-                    .onAppear {
-                        isBirthdayFocused = true
-                    }
-                    .keyboardType(.numberPad)
-                    .padding(.top, 20)
-                    .transition(.move(edge: .bottom).combined(with: .opacity))
+                CustomNavigationBarView(navigationCase: .signup) {
+                    store.send(.backButtonTapped)
                 }
                 
-                Spacer()
-                
-                Text("다음이 마지막 단계입니다!")
-                    .font(DesignSystem.Font.medium12, lineHeight: 16)
-                    .foregroundStyle(Color.black60)
-                    .padding(.bottom, 12)
-                
-                CustomBottomButton(
-                    type: .next,
-                    isEnable: $store.isButtonEnabled
-                ) {
-                    store.send(.nextButtonTapped)
+                VStack(spacing: 0) {
+                    Spacer()
+                    
+                    CustomTextFieldView(
+                        type: .nickname,
+                        text: $store.nickname,
+                        isFocused: $isNicknameFieldFocused,
+                        state: $store.nicknameState
+                    )
+                    .offset(y: store.signupState == .inputBirthday ? -20 : 0)
+                    .animation(.easeInOut, value: store.signupState)
+                    
+                    if store.signupState == .inputBirthday {
+                        CustomTextFieldView(
+                            type: .birthday,
+                            text: $store.birthday,
+                            isFocused: $isBirthdayFocused,
+                            state: $store.birthdayState
+                        )
+                        .onAppear {
+                            isBirthdayFocused = true
+                        }
+                        .keyboardType(.numberPad)
+                        .padding(.top, 20)
+                        .transition(.move(edge: .bottom).combined(with: .opacity))
+                    }
+                    
+                    Spacer()
+                    
+                    Text("다음이 마지막 단계입니다!")
+                        .font(DesignSystem.Font.medium12, lineHeight: 16)
+                        .foregroundStyle(Color.black60)
+                        .padding(.bottom, 12)
+                    
+                    CustomBottomButton(
+                        type: .next,
+                        isEnable: $store.isButtonEnabled
+                    ) {
+                        store.send(.nextButtonTapped)
+                    }
                 }
                 .padding(.bottom, 20)
+                .padding(.horizontal, 40)
             }
-            .padding(.horizontal, 40)
             .animation(.easeInOut, value: store.signupState)
         }
         .onAppear {
@@ -87,23 +93,7 @@ public struct SignupView: View {
         }
         .navigationBarBackButtonHidden(true)
         .background(alertHostingView)
-        .toolbar {
-            ToolbarItem(placement: .navigationBarLeading) {
-                Button {
-                    store.send(.backButtonTapped)
-                } label: {
-                    HStack(spacing: 0) {
-                        Image.arrowBack
-                            .padding(.trailing, 5)
-                        
-                        Text("회원가입")
-                            .font(DesignSystem.Font.medium24, lineHeight: 32)
-                            .foregroundStyle(Color.black100)
-                    }
-                }
-                .padding(.top, 16)
-            }
-        }
+        .background(InteractivePopGestureEnabler())
     }
     
     @ViewBuilder

--- a/Soongan/Feature/ContestFeature/Sources/View/ContestView.swift
+++ b/Soongan/Feature/ContestFeature/Sources/View/ContestView.swift
@@ -163,35 +163,37 @@ public struct ContestView: View {
     }
     
     func navigationTitle(contestIndex: Int, weekTopic: String) -> some View {
-        ZStack(alignment: .trailing) {
-            ZStack(alignment: .leading) {
-                HStack{
-                    Text("\(contestIndex)회차")
-                    
-                    Text("|")
-                    
-                    Text(weekTopic)
-                }
-                .frame(width: 150)
-                
+        ZStack {
+            HStack {
                 Button(action: {
                     store.send(.sheet(.present))
                 }) {
                     Image.downArrow
                         .scaleEffect(x: 1, y: store.isContestSheetPresented ? -1 : 1)
                 }
+                
+                HStack {
+                    Text("\(contestIndex)회차")
+                    
+                    Text("|")
+                    
+                    Text(weekTopic)
+                }
             }
-            .frame(maxWidth: .infinity)
+            .offset(x: -10)
             
-            Button {
-                store.send(.uiAction(.sortContestContentTapped))
-            } label: {
-                Image.sortOption
-                    .padding(.trailing, 14)
+            HStack {
+                Spacer()
+                Button {
+                    store.send(.uiAction(.sortContestContentTapped))
+                } label: {
+                    Image.sortOption
+                }
+                .padding(.trailing, 14)
             }
         }
         .font(DesignSystem.Font.bold20)
-        .foregroundStyle(Color.black100)
+        .foregroundStyle(DesignSystem.Color.black100)
         .padding(.vertical, 14)
         .background(DesignSystem.Color.soonganBG)
     }

--- a/Soongan/Feature/ContestFeature/Sources/View/ContestView.swift
+++ b/Soongan/Feature/ContestFeature/Sources/View/ContestView.swift
@@ -164,7 +164,7 @@ public struct ContestView: View {
     
     func navigationTitle(contestIndex: Int, weekTopic: String) -> some View {
         ZStack {
-            HStack {
+            HStack(spacing: 8) {
                 Button(action: {
                     store.send(.sheet(.present))
                 }) {
@@ -172,16 +172,17 @@ public struct ContestView: View {
                         .scaleEffect(x: 1, y: store.isContestSheetPresented ? -1 : 1)
                 }
                 
-                HStack {
+                HStack(spacing: 4) {
                     Text("\(contestIndex)회차")
-                    
                     Text("|")
-                    
                     Text(weekTopic)
                 }
+                
+                // 왼쪽 버튼과 동일한 공간을 차지하는 보이지 않는 뷰 (균형 유지용)
+                Image.downArrow
+                    .hidden()
             }
-            .offset(x: -10)
-            
+
             HStack {
                 Spacer()
                 Button {
@@ -189,8 +190,8 @@ public struct ContestView: View {
                 } label: {
                     Image.sortOption
                 }
-                .padding(.trailing, 14)
             }
+            .padding(.trailing, 14)
         }
         .font(DesignSystem.Font.bold20)
         .foregroundStyle(DesignSystem.Color.black100)

--- a/Soongan/Feature/DetailContestFeature/Sources/View/ContestDetailView.swift
+++ b/Soongan/Feature/DetailContestFeature/Sources/View/ContestDetailView.swift
@@ -129,25 +129,16 @@ public struct ContestDetailView: View {
             .background(alertHostingView)
             .toolbar(.hidden, for: .tabBar)
             .navigationBarBackButtonHidden(true)
-            .toolbar {
-                ToolbarItem(placement: .navigationBarLeading) {
-                    Button {
-                        store.send(.backButtonTapped)
-                    } label: {
-                        HStack(spacing: 0) {
-                            Image.arrowBack
-                                .padding(.trailing, 5)
-                        }
-                    }
-                    .padding(.top, 16)
-                }
-            }
     }
     
     @ViewBuilder
     private var baseView: some View {
         ZStack(alignment: .bottom) {
             VStack(spacing: 0) {
+                CustomNavigationBarView(navigationCase: .backButton) {
+                    store.send(.backButtonTapped)
+                }
+                
                 Spacer()
                 
                 if let url = store.imageUrl {

--- a/Soongan/Feature/MypageFeature/Sources/View/AlarmListView.swift
+++ b/Soongan/Feature/MypageFeature/Sources/View/AlarmListView.swift
@@ -28,6 +28,10 @@ public struct AlarmListView: View {
     
     public var body: some View {
         VStack(spacing: 0) {
+            CustomNavigationBarView(navigationCase: .title("알림")) {
+                store.send(.backButtonTapped)
+            }
+            
             HStack(spacing: 18) {
                 TopTabButtonView(
                     title: "대회 알림" + (store.unreadNotificationCount[.contest].flatMap { $0 > 0 ? " \($0)" : nil } ?? ""),
@@ -67,26 +71,6 @@ public struct AlarmListView: View {
         .background(DesignSystem.Color.soonganBG)
         .background(InteractivePopGestureEnabler())
         .navigationBarBackButtonHidden(true)
-        .toolbar {
-            ToolbarItem(placement: .navigationBarLeading) {
-                Button {
-                    store.send(.backButtonTapped)
-                } label: {
-                    HStack(spacing: 0) {
-                        Image.arrowBack
-                            .padding(.trailing, 5)
-                    }
-                }
-                .padding(.top, 16)
-            }
-            
-            ToolbarItem(placement: .principal) {
-                Text("알림")
-                    .font(DesignSystem.Font.bold16, lineHeight: 20)
-                    .foregroundColor(DesignSystem.Color.black100)
-                    .padding(.top, 16)
-            }
-        }
     }
     
     @ViewBuilder

--- a/Soongan/Feature/MypageFeature/Sources/View/EditProfileView.swift
+++ b/Soongan/Feature/MypageFeature/Sources/View/EditProfileView.swift
@@ -48,6 +48,10 @@ public struct EditProfileView: View {
                 }
             
             VStack {
+                CustomNavigationBarView(navigationCase: .backButton) {
+                    store.send(.backButtonTapped)
+                }
+                
                 profileImageSection()
                     .padding(.top, 42)
                     .padding(.bottom, 40)
@@ -67,19 +71,6 @@ public struct EditProfileView: View {
         }
         .background(InteractivePopGestureEnabler())
         .navigationBarBackButtonHidden(true)
-        .toolbar {
-            ToolbarItem(placement: .navigationBarLeading) {
-                Button {
-                    store.send(.backButtonTapped)
-                } label: {
-                    HStack(spacing: 0) {
-                        Image.arrowBack
-                            .padding(.trailing, 5)
-                    }
-                }
-                .padding(.top, 16)
-            }
-        }
         .onAppear {
             store.send(.onAppear)
         }

--- a/Soongan/Feature/MypageFeature/Sources/View/QuestionsListView.swift
+++ b/Soongan/Feature/MypageFeature/Sources/View/QuestionsListView.swift
@@ -28,6 +28,10 @@ struct QuestionsListView: View {
     
     var body: some View {
         VStack(spacing: 0) {
+            CustomNavigationBarView(navigationCase: .title("FAQ")) {
+                store.send(.backButtonTapped)
+            }
+            
             HStack(alignment: .bottom, spacing: 18) {
                 TopTabButtonView(
                     title: "기본",
@@ -79,26 +83,6 @@ struct QuestionsListView: View {
         .navigationBarBackButtonHidden(true)
         .onAppear {
             store.send(.onAppear)
-        }
-        .toolbar {
-            ToolbarItem(placement: .navigationBarLeading) {
-                Button {
-                    store.send(.backButtonTapped)
-                } label: {
-                    HStack(spacing: 0) {
-                        Image.arrowBack
-                            .padding(.trailing, 5)
-                    }
-                }
-                .padding(.top, 16)
-            }
-            
-            ToolbarItem(placement: .principal) {
-                Text("FAQ")
-                    .font(DesignSystem.Font.bold16, lineHeight: 20)
-                    .foregroundColor(DesignSystem.Color.black100)
-                    .padding(.top, 16)
-            }
         }
     }
     

--- a/Soongan/Feature/PostPictureFeature/Sources/View/PostPictureView.swift
+++ b/Soongan/Feature/PostPictureFeature/Sources/View/PostPictureView.swift
@@ -45,6 +45,10 @@ public struct PostPictureView: View {
                 }
             
             VStack(spacing: 0) {
+                CustomNavigationBarView(navigationCase: .postImage(round: store.round, weekTopic: store.weekTopic)) {
+                    store.send(.backButtonTapped)
+                }
+                
                 postPictureSection()
                     .padding(.bottom, 36)
                 
@@ -97,24 +101,6 @@ public struct PostPictureView: View {
             ) {
                 CustomSheetView<NeverOption>(type: .postPicture(name: store.postPictureName)) {
                     store.send(.postButtonTappedInSheet)
-                }
-            }
-            .toolbar {
-                ToolbarItem(placement: .navigationBarLeading) {
-                    Button {
-                        store.send(.backButtonTapped)
-                    } label: {
-                        Image.arrowBack
-                            .padding(.trailing, 5)
-                    }
-                    .padding(.top, 26)
-                    .padding(.bottom, 10)
-                }
-                
-                ToolbarItem(placement: .principal) {
-                    navigationTitle(round: store.round, weekTopic: store.weekTopic)
-                        .padding(.top, 26)
-                        .padding(.bottom, 10)
                 }
             }
         }


### PR DESCRIPTION
## 📟 관련 이슈
- Resolved: #48 

<br>

## 👷 작업한 내용
<!-- 작업한 내용을 적어주세요. -->
- 기존 SwiftUI의 `toolbar`를 `CustomNavigationBarView`로 교체하여 네비게이션 UI의 일관성을 확보
- iOS 26 리퀴드 글래스 대응하고 여러 화면에 분산되어 있던 네비게이션 바 구성을 중앙에서 관리하여 유지보수성을 향상
- `SignupView`, `ContestDetailView`, `AlarmListView`, `EditProfileView`, `QuestionsListView`, `PostPictureView`에 `CustomNavigationBarView`를 적용
- `ContestView`의 네비게이션 타이틀 정렬 및 UI를 개선

<br>

## 🚨 참고 사항
<!-- 참고 사항을 적어주세요. 없으면 지워주세요. -->

### 1. `CustomNavigationBarView` 사용법

`CustomNavigationBarView`는 화면의 네비게이션 바를 일관된 디자인으로 쉽게 생성하기 위해 제작된 재사용 가능한 컴포넌트입니다.
`navigationCase`와 `backAction` 클로저를 파라미터로 받습니다.

```swift
public init(
    navigationCase: NavigationCase,
    backAction: @escaping () -> Void
)
```

<br>

#### NavigationCase 종류 및 사용 예시

`NavigationCase` 열거형을 통해 네비게이션 바의 타입을 지정할 수 있습니다.

1.  **`.signup`**: 회원가입 화면에서 사용합니다. 뒤로가기 버튼과 "회원가입" 타이틀이 함께 표시됩니다.
    ```swift
    CustomNavigationBarView(navigationCase: .signup) {
        // 뒤로가기 액션
    }
    ```

2.  **`.title(String)`**: 일반적인 화면에서 사용하며, 중앙에 커스텀 타이틀을 표시합니다.
    ```swift
    CustomNavigationBarView(navigationCase: .title("알림")) {
        // 뒤로가기 액션
    }
    ```

3.  **`.backButton`**: 타이틀 없이 뒤로가기 버튼만 필요한 경우에 사용합니다.
    ```swift
    CustomNavigationBarView(navigationCase: .backButton) {
        // 뒤로가기 액션
    }
    ```

4.  **`.postImage(round: Int, weekTopic: String)`**: 이미지 포스팅 화면 전용으로, 회차와 주제를 타이틀로 표시합니다.
    ```swift
    CustomNavigationBarView(navigationCase: .postImage(round: 10, weekTopic: "우주")) {
        // 뒤로가기 액션
    }
    ```

<br>

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
