### PR TITLE
[Refactor] #50 - 콘테스트 기간 관련한 HomeView UI 로직 수정

### DIFF
--- a/Soongan/Core/CoreNetwork/Sources/Home/SearchHomeInfoResponseDTO.swift
+++ b/Soongan/Core/CoreNetwork/Sources/Home/SearchHomeInfoResponseDTO.swift
@@ -13,6 +13,7 @@ public struct SearchHomeInfoResponseDTO: Decodable {
 }
 
 public struct ContestInfoData: Decodable {
+    public let status: String
     public let contestType: String
     public let subject: String
     public let startAt: String

--- a/Soongan/Feature/HomeFeature/Sources/Enum/HomeStateType.swift
+++ b/Soongan/Feature/HomeFeature/Sources/Enum/HomeStateType.swift
@@ -9,6 +9,8 @@ import Foundation
 
 enum HomeStateType {
     case loading
-    case endTopic
+    case upcoming
     case inProgress
+    case endTopic
+    case error
 }

--- a/Soongan/Feature/HomeFeature/Sources/Logic/HomeFeature.swift
+++ b/Soongan/Feature/HomeFeature/Sources/Logic/HomeFeature.swift
@@ -130,37 +130,40 @@ public struct HomeFeature {
                 let contestData = result.contestInfo
                 let postData = result.postInfo
                 state.isAddPostImage = postData.count == 3
-                
-                if let endDate = Self.dateFormatter.date(from: contestData.endAt) {
-                    if endDate < Date() {
-                        state.weekTopic = "-회차 종료-"
-                        state.homeState = .endTopic
-                    } else {
-                        state.startPeriod = contestData.startAt.toFormattedDateString()
-                        state.endPeriod = contestData.endAt.toFormattedDateString()
-                        
-                        state.postImageData = postData.map {
-                            PostImageModel(
-                                id: $0.postId,
-                                imageURL: $0.imageUrl,
-                                likeCount: $0.likeCount,
-                                commentCount: $0.commentCount,
-                                isLiked: $0.isLiked
-                            )
-                        }
-                        
-                        state.homeState = .inProgress
-                        state.weekTopic = contestData.subject
+
+                // status에 따른 HomeStateType 변환
+                switch contestData.status {
+                case "IN_PROGRESS":
+                    state.homeState = .inProgress
+                    state.weekTopic = contestData.subject
+                    state.startPeriod = contestData.startAt
+                    state.endPeriod = contestData.endAt
+                    
+                    state.postImageData = postData.map {
+                        PostImageModel(
+                            id: $0.postId,
+                            imageURL: $0.imageUrl,
+                            likeCount: $0.likeCount,
+                            commentCount: $0.commentCount,
+                            isLiked: $0.isLiked
+                        )
                     }
-                } else {
-                    state.weekTopic = "-회차 종료-"
+                    
+                case "CLOSED", "UPCOMING":
                     state.homeState = .endTopic
+                    state.weekTopic = "-회차 종료-"
+                    
+                default:
+                    state.homeState = .error
+                    state.weekTopic = "-알수 없음-"
                 }
 
                 return .none
                 
-            case .networkAction(.homeInfoFailure(let error)):
-                print(error)
+            case .networkAction(.homeInfoFailure(_)):
+                state.homeState = .error
+                state.weekTopic = "-알수 없음-"
+                
                 return .none
                 
             case .showExplain(let reportId, let targetType):

--- a/Soongan/Feature/HomeFeature/Sources/View/HomeView.swift
+++ b/Soongan/Feature/HomeFeature/Sources/View/HomeView.swift
@@ -37,10 +37,6 @@ public struct HomeView: View {
                 DesignSystem.Color.soonganBG.ignoresSafeArea()
                 
                 VStack(spacing: 0) {
-                    topheaderView()
-                        .padding(.horizontal, 36)
-                        .padding(.bottom, 60)
-                    
                     switch store.homeState {
                     case .loading:
                         VStack {
@@ -53,8 +49,10 @@ public struct HomeView: View {
                         }
                     case .inProgress:
                         inProgressMainSection()
-                    case .endTopic:
+                    case .endTopic, .upcoming:
                         endTopicMainSection()
+                    case .error:
+                        erorrMainSection()
                     }
                 }
                 .padding(.top, 69)
@@ -100,6 +98,8 @@ private extension HomeView {
                 .resizable()
                 .frame(width: 33, height: 50)
         }
+        .padding(.horizontal, 36)
+        .padding(.bottom, 60)
     }
     
     func weekTopicTopHeader() -> some View {
@@ -117,6 +117,8 @@ private extension HomeView {
 
     func inProgressMainSection() -> some View {
         VStack(spacing: 0) {
+            topheaderView()
+            
             if store.postImageData.isEmpty {
                 Button(action: {
                     store.send(.uiAction(.addPictureButtonTapped))
@@ -167,6 +169,8 @@ private extension HomeView {
     
     func endTopicMainSection() -> some View {
         VStack(spacing: 0) {
+            topheaderView()
+            
             Spacer()
             
             VStack(spacing: 0) {
@@ -181,6 +185,34 @@ private extension HomeView {
                 store.send(.uiAction(.showContestButtonTapped))
             }) {
                 Text("보러가기")
+                    .font(DesignSystem.Font.regular15)
+                    .foregroundStyle(DesignSystem.Color.black100)
+                    .underline(color: DesignSystem.Color.black100)
+            }
+            .padding(.bottom, 100)
+            
+            Spacer()
+        }
+    }
+    
+    func erorrMainSection() -> some View {
+        VStack(spacing: 0) {
+            topheaderView()
+            
+            Spacer()
+            
+            VStack(spacing: 0) {
+                Text("데이터를 불러오는 중 문제가 발생했어요.\n잠시 후에 다시 시도해 보세요.")
+                    .multilineTextAlignment(.center)
+            }
+            .font(DesignSystem.Font.regular15)
+            .foregroundStyle(DesignSystem.Color.black100)
+            .padding(.bottom, 50)
+            
+            Button(action: {
+                store.send(.onAppear)
+            }) {
+                Text("다시 불러오기")
                     .font(DesignSystem.Font.regular15)
                     .foregroundStyle(DesignSystem.Color.black100)
                     .underline(color: DesignSystem.Color.black100)

--- a/Soongan/Feature/PostPictureFeature/Sources/View/PostPictureView.swift
+++ b/Soongan/Feature/PostPictureFeature/Sources/View/PostPictureView.swift
@@ -49,6 +49,8 @@ public struct PostPictureView: View {
                     store.send(.backButtonTapped)
                 }
                 
+                Spacer()
+                
                 postPictureSection()
                     .padding(.bottom, 36)
                 
@@ -89,7 +91,7 @@ public struct PostPictureView: View {
                 .padding(.horizontal, 136)
                 .padding(.bottom, 95)
             }
-            .padding(.top, 50)
+//            .padding(.top, 50)
             .frame(maxHeight: .infinity, alignment: .top)
             .toolbar(.hidden, for: .tabBar)
             .navigationBarBackButtonHidden(true)


### PR DESCRIPTION
## 📟 관련 이슈
- Resolved: #50 

<br>

## 👷 작업한 내용
<!-- 작업한 내용을 적어주세요. -->
- 홈 화면 로직 리팩토링: 기존에 날짜를 직접 비교하여 상태를 관리하던 방식에서 서버에서 내려주는 `status` 값을 사용하도록 로직을 변경
- 상태 분기 처리 강화: API 응답의 `status`(IN_PROGRESS, CLOSED 등)에 따라 홈 화면의 상태(`homeState`)가 결정되도록 분기 처리
- 에러 화면 추가: 홈 화면 데이터 로드 실패 시, 사용자에게 문제를 알리고 재시도를 유도하는 에러 UI 추가
- 뷰 구조 개선: 각 상태(inProgress, endTopic, error)에 따라 뷰가 독립적으로 헤더를 갖도록 구조를 개선

<br>

## 🚨 참고 사항
<!-- 참고 사항을 적어주세요. 없으면 지워주세요. -->

### 1. 홈 화면 상태 관리 로직 변경

기존에는 홈 화면에서 클라이언트가 직접 날짜를 계산하여 대회 진행 상태를 판단했습니다. 이 방식은 서버와 클라이언트 간의 상태 불일치를 유발할 수 있어, 서버에서 제공하는 `status` 필드를 직접 사용하도록 리팩토링했습니다.


### 2. 에러 처리 UI 추가

API 요청이 실패하거나 알 수 없는 `status` 를 수신했을 때, 사용자 경험을 개선하기 위해 에러 상태와 전용 UI를 추가했습니다.

<br>

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
