### PR TITLE
[Refactor] #54 - 콘테스트 목록 관련한 뷰 기능 및 사용자 경험 개선 

### DIFF
--- a/Soongan/Core/CoreNetwork/Sources/WeeklyContest/DTO/Response/SearchMyContestResponseDTO.swift
+++ b/Soongan/Core/CoreNetwork/Sources/WeeklyContest/DTO/Response/SearchMyContestResponseDTO.swift
@@ -18,4 +18,6 @@ public struct SearchMyContestInfoData: Decodable {
     public let postId: Int
     public let imageUrl: String
     public let likeCount: Int
+    public let reportCount: Int
+    public let ratio: Double
 }

--- a/Soongan/Core/CoreNetwork/Sources/WeeklyContest/DTO/Response/SearchWeeklyContestResponseDTO.swift
+++ b/Soongan/Core/CoreNetwork/Sources/WeeklyContest/DTO/Response/SearchWeeklyContestResponseDTO.swift
@@ -19,6 +19,8 @@ public struct PostInfoData: Decodable {
     public let profileImageUrl: String
     public let postId: Int
     public let imageUrl: String
+    public let reportCount: Int
+    public let ratio: Double
 }
 
 public struct PageInfoData: Decodable {

--- a/Soongan/DesignSystem/Sources/Component/ContestImageView.swift
+++ b/Soongan/DesignSystem/Sources/Component/ContestImageView.swift
@@ -17,14 +17,8 @@ public struct ContestImageView: View {
     
     // MARK: - Properties
     
-    /// 이미지 뷰를 구성하는데 필요한 데이터 모델 (`id`, `imageUrl`, `height`)
+    /// 이미지 뷰를 구성하는데 필요한 데이터 모델
     let model: ContestImageModel
-    
-    /// 부모 뷰의 크기 정보를 제공하는 `GeometryProxy`
-    let geometry: GeometryProxy
-    
-    /// 이미지 로드 성공 시 호출될 클로저. 이미지의 `id`와 계산된 `height`를 전달합니다.
-    let onSuccessAction: (Int, CGFloat) -> Void
     
     /// 이미지를 탭했을 때 호출될 클로저. 탭된 이미지의 `id`를 전달합니다.
     let onTapAction: (Int) -> Void
@@ -33,13 +27,9 @@ public struct ContestImageView: View {
     
     public init(
         model: ContestImageModel,
-        geometry: GeometryProxy,
-        onSuccessAction: @escaping (Int, CGFloat) -> Void,
         onTapAction: @escaping (Int) -> Void
     ) {
         self.model = model
-        self.geometry = geometry
-        self.onSuccessAction = onSuccessAction
         self.onTapAction = onTapAction
     }
     
@@ -50,26 +40,8 @@ public struct ContestImageView: View {
             .placeholder {
                 SkeletonView()
             }
-            .onSuccess { result in
-                // 원본 이미지의 사이즈와 비율을 가져옴
-                let size = result.image.size
-                let ratio = size.height / size.width
-                
-                // 화면의 절반 너비를 기준으로 이미지의 너비를 계산 (양쪽 패딩 24 고려)
-                let width = (geometry.size.width - 24) / 2
-                
-                // 계산된 너비와 원본 이미지 비율을 사용하여 최종 높이를 계산
-                let calculatedHeight = CGFloat(width) * ratio
-                
-                // 모델의 높이 값이 아직 설정되지 않은 경우에만 높이 업데이트 액션을 호출
-                // (이미 높이가 계산된 경우 중복 호출 방지)
-                if model.height == nil {
-                    onSuccessAction(model.id, calculatedHeight)
-                }
-            }
             .resizable()
             .aspectRatio(contentMode: .fit)
-            .frame(width: (geometry.size.width - 24) / 2, height: model.height)
             .onTapGesture {
                 onTapAction(model.id)
             }

--- a/Soongan/DesignSystem/Sources/Component/CustomSheetView.swift
+++ b/Soongan/DesignSystem/Sources/Component/CustomSheetView.swift
@@ -683,7 +683,6 @@ struct PostPictureContentSectionView: View {
             HStack(spacing: 0) {
                 Button(action: {
                     isChecked.toggle()
-                    print("버튼 눌림", isChecked)
                 }) {
                     ZStack {
                         Rectangle()
@@ -710,6 +709,8 @@ struct PostPictureContentSectionView: View {
             }
             .padding(.horizontal, 20)
             
+            Spacer()
+            
             CustomBottomButton(
                 type: .complete,
                 isEnable: $isChecked,
@@ -718,7 +719,7 @@ struct PostPictureContentSectionView: View {
                     dismiss()
                 }
             )
-            .padding(.top, 16)
+            //.padding(.top, 16)
         }
         .font(DesignSystem.Font.regular16, lineHeight: 24)
         .foregroundStyle(Color.black)

--- a/Soongan/DesignSystem/Sources/Component/WaterfallImageGridView.swift
+++ b/Soongan/DesignSystem/Sources/Component/WaterfallImageGridView.swift
@@ -8,14 +8,14 @@
 import SwiftUI
 import Shared
 
-// MARK: - ScrollPositionState
-
-struct ScrollPositionState: Equatable {
-    let offsetY: CGFloat
-    let reachedBottom: Bool
-}
-
 public struct WaterfallImageGridView: View {
+    
+    // MARK: - ScrollPositionState
+    
+    private struct ScrollPositionState: Equatable {
+        let offsetY: CGFloat
+        let reachedBottom: Bool
+    }
     
     // MARK: - Properties
     
@@ -133,27 +133,22 @@ public struct WaterfallImageGridView: View {
                         onRefresh?()
                     }
                     .onAppear {
-                        print("onAppear - posts 개수: \(posts.count)")
                         screenWidth = geometry.size.width
-                        print("onAppear - screenWidth: \(screenWidth)")
+                        
                         if !posts.isEmpty && screenWidth > 0 {
-                            print("onAppear에서 distributePosts 호출")
                             distributePosts(posts)
                         }
                     }
                     .onChange(of: geometry.size.width) { _, newWidth in
                         screenWidth = newWidth
-                        print("현재 width:", screenWidth)
+                        
                         if !posts.isEmpty {
                             distributePosts(posts)
                         }
                     }
                     .onChange(of: posts) { _, newPosts in
-                        print("onChange(posts) - 개수: \(newPosts.count), screenWidth: \(screenWidth)")
                         if screenWidth > 0 {
                             distributePosts(newPosts)
-                        } else {
-                            print("screenWidth가 0이라서 distributePosts 건너뜀")
                         }
                     }
                     .scrollPosition($scrollPosition, anchor: .bottom)
@@ -204,6 +199,11 @@ public struct WaterfallImageGridView: View {
     ///
     /// - Parameter posts: 분배할 게시글 배열
     private func distributePosts(_ posts: [ContestImageModel]) {
+        // 레이아웃 관련 상수 정의
+        let horizontalPadding: CGFloat = 9
+        let columnSpacing: CGFloat = 7
+        let itemSpacing: CGFloat = 8
+
         // 좌우 컬럼의 누적 높이 추적 변수
         var leftHeight: CGFloat = 0
         var rightHeight: CGFloat = 0
@@ -212,26 +212,24 @@ public struct WaterfallImageGridView: View {
         var leftItems: [ContestImageModel] = []
         var rightItems: [ContestImageModel] = []
         
-        let columnWidth = (screenWidth - 25) / 2
+        let totalHorizontalSpacing = horizontalPadding * 2 + columnSpacing
+        let columnWidth = (screenWidth - totalHorizontalSpacing) / 2
         
         // 모든 게시글을 순차적으로 처리
         for post in posts {
             // ratio는 width/height 비율
             // 실제 화면에서 표시될 이미지 높이 계산
-            // - 현재 뷰의 폭에서 좌우 패딩(9*2) + 컬럼간격(7) = 25 제외
-            // - 남은 폭을 2로 나누어 각 컬럼 폭 구하기
-            // - 컬럼 폭을 ratio로 나누어서 실제 표시 높이 계산 (width/ratio = height)
             let imageHeight = columnWidth / CGFloat(post.ratio)
             
             // 현재 좌우 컬럼의 높이를 비교하여 더 낮은 쪽에 배치
             if leftHeight <= rightHeight {
                 // 왼쪽이 더 낮거나 같으면 왼쪽에 추가
                 leftItems.append(post)
-                leftHeight += imageHeight + 8 // 이미지 높이 + 컬럼 내 간격
+                leftHeight += imageHeight + itemSpacing // 이미지 높이 + 컬럼 내 간격
             } else {
                 // 오른쪽이 더 낮으면 오른쪽에 추가
                 rightItems.append(post)
-                rightHeight += imageHeight + 8 // 이미지 높이 + 컬럼 내 간격
+                rightHeight += imageHeight + itemSpacing // 이미지 높이 + 컬럼 내 간격
             }
         }
         

--- a/Soongan/DesignSystem/Sources/Component/WaterfallImageGridView.swift
+++ b/Soongan/DesignSystem/Sources/Component/WaterfallImageGridView.swift
@@ -1,0 +1,246 @@
+//
+//  WaterfallImageGridView.swift
+//  DesignSystem
+//
+//  Created by ParkJunHyuk on 12/3/25.
+//
+
+import SwiftUI
+import Shared
+
+// MARK: - ScrollPositionState
+
+struct ScrollPositionState: Equatable {
+    let offsetY: CGFloat
+    let reachedBottom: Bool
+}
+
+public struct WaterfallImageGridView: View {
+    
+    // MARK: - Properties
+    
+    let posts: [ContestImageModel]
+    let hasMorePages: Bool
+    let isLoading: Bool
+    let isInitialLoading: Bool
+    let onRefresh: (() -> Void)?
+    let onLoadMore: (() -> Void)?
+    let onImageTap: ((Int) -> Void)?
+    let onScrollPositionChange: ((CGFloat) -> Void)?
+    
+    @State private var leftColumnPosts: [ContestImageModel] = []
+    @State private var rightColumnPosts: [ContestImageModel] = []
+    @State private var screenWidth: CGFloat = 0
+    @State private var scrollPosition: ScrollPosition = ScrollPosition(idType: ContestImageModel.ID.self)
+    @State private var isTopButtonVisible: Bool = false
+    
+    // MARK: - Init
+    
+    public init(
+        posts: [ContestImageModel],
+        hasMorePages: Bool,
+        isLoading: Bool,
+        isInitialLoading: Bool = true,
+        onRefresh: (() -> Void)? = nil,
+        onLoadMore: (() -> Void)? = nil,
+        onImageTap: ((Int) -> Void)? = nil,
+        onScrollPositionChange: ((CGFloat) -> Void)? = nil
+    ) {
+        self.posts = posts
+        self.hasMorePages = hasMorePages
+        self.isLoading = isLoading
+        self.isInitialLoading = isInitialLoading
+        self.onRefresh = onRefresh
+        self.onLoadMore = onLoadMore
+        self.onImageTap = onImageTap
+        self.onScrollPositionChange = onScrollPositionChange
+    }
+    
+    // MARK: - Body
+    
+    public var body: some View {
+        GeometryReader { geometry in
+            ZStack(alignment: .bottomTrailing) {
+                if isInitialLoading {
+                    // 초기 로딩 스켈레톤 UI
+                    HStack(alignment: .top, spacing: 7) {
+                        // 왼쪽 스켈레톤 컬럼
+                        VStack(spacing: 8) {
+                            ForEach(0..<3, id: \.self) { _ in
+                                SkeletonView()
+                                    .frame(width: max(0, geometry.size.width / 2 - 13), height: 200)
+                            }
+                        }
+                        
+                        // 오른쪽 스켈레톤 컬럼
+                        VStack(spacing: 8) {
+                            ForEach(0..<3, id: \.self) { _ in
+                                SkeletonView()
+                                    .frame(width: max(0, geometry.size.width / 2 - 13), height: 250)
+                            }
+                        }
+                    }
+                    .padding(.horizontal, 9)
+                    .transition(.opacity.animation(.easeInOut))
+                } else {
+                    ScrollView {
+                        LazyVStack(spacing: 0) {
+                            HStack(alignment: .top, spacing: 7) {
+                                // 왼쪽 컬럼
+                                LazyVStack(spacing: 8) {
+                                    ForEach(leftColumnPosts) { post in
+                                        ContestImageView(
+                                            model: post,
+                                            onTapAction: { id in onImageTap?(id) }
+                                        )
+                                    }
+                                }
+                                
+                                // 오른쪽 컬럼
+                                LazyVStack(spacing: 8) {
+                                    ForEach(rightColumnPosts) { post in
+                                        ContestImageView(
+                                            model: post,
+                                            onTapAction: { id in onImageTap?(id) }
+                                        )
+                                    }
+                                }
+                            }
+                            .padding(.horizontal, 9)
+                            
+                            // 무한스크롤 로딩 인디케이터 & 트리거
+                            if hasMorePages {
+                                HStack {
+                                    Spacer()
+                                    if isLoading {
+                                        ProgressView()
+                                            .progressViewStyle(CircularProgressViewStyle())
+                                            .padding()
+                                    } else {
+                                        // 투명한 뷰로 스크롤 감지
+                                        Color.clear
+                                            .frame(height: 50)
+                                            .onAppear {
+                                                onLoadMore?()
+                                            }
+                                    }
+                                    Spacer()
+                                }
+                            }
+                        }
+                    }
+                    .refreshable {
+                        onRefresh?()
+                    }
+                    .onAppear {
+                        print("onAppear - posts 개수: \(posts.count)")
+                        screenWidth = geometry.size.width
+                        print("onAppear - screenWidth: \(screenWidth)")
+                        if !posts.isEmpty && screenWidth > 0 {
+                            print("onAppear에서 distributePosts 호출")
+                            distributePosts(posts)
+                        }
+                    }
+                    .onChange(of: geometry.size.width) { _, newWidth in
+                        screenWidth = newWidth
+                        print("현재 width:", screenWidth)
+                        if !posts.isEmpty {
+                            distributePosts(posts)
+                        }
+                    }
+                    .onChange(of: posts) { _, newPosts in
+                        print("onChange(posts) - 개수: \(newPosts.count), screenWidth: \(screenWidth)")
+                        if screenWidth > 0 {
+                            distributePosts(newPosts)
+                        } else {
+                            print("screenWidth가 0이라서 distributePosts 건너뜀")
+                        }
+                    }
+                    .scrollPosition($scrollPosition, anchor: .bottom)
+                    .onScrollGeometryChange(for: ScrollPositionState.self) { geometry in
+                        let offsetY = geometry.bounds.origin.y
+                        let reachedBottom = geometry.visibleRect.maxY >= geometry.contentSize.height + 100
+                        return ScrollPositionState(offsetY: offsetY, reachedBottom: reachedBottom)
+                    } action: { oldValue, newValue in
+                        // 스크롤 위치를 외부로 전달
+                        onScrollPositionChange?(newValue.offsetY)
+                        
+                        // 상단 버튼 표시 여부 결정
+                        isTopButtonVisible = newValue.offsetY > 200
+                    }
+                    
+                    // 상단 이동 버튼 (초기 로딩 중이 아닐 때만 표시)
+                    if !isInitialLoading {
+                        Button {
+                            withAnimation(.easeInOut) {
+                                scrollPosition.scrollTo(edge: .top)
+                            }
+                        } label: {
+                            Image(systemName: "arrow.up")
+                                .padding()
+                                .background(Color.white)
+                                .foregroundColor(DesignSystem.Color.black100)
+                                .clipShape(Circle())
+                                .shadow(radius: 4)
+                                .padding()
+                        }
+                        .opacity(isTopButtonVisible ? 1 : 0)
+                        .allowsHitTesting(isTopButtonVisible)
+                        .animation(.easeInOut, value: isTopButtonVisible)
+                    }
+                }
+            }
+        }
+    }
+    
+    // MARK: - Private Methods
+    
+    /// Waterfall 레이아웃을 위해 게시글을 좌우 두 컬럼에 균형있게 분배하는 메서드
+    ///
+    /// 동작 원리:
+    /// 1. 각 이미지의 원본 비율을 이용해 화면에서 실제 표시될 높이를 계산
+    /// 2. 좌우 컬럼의 누적 높이를 비교하여 더 낮은 쪽에 배치
+    /// 3. 결과적으로 좌우 컬럼의 높이가 비슷하게 유지되어 균형잡힌 레이아웃 구현
+    ///
+    /// - Parameter posts: 분배할 게시글 배열
+    private func distributePosts(_ posts: [ContestImageModel]) {
+        // 좌우 컬럼의 누적 높이 추적 변수
+        var leftHeight: CGFloat = 0
+        var rightHeight: CGFloat = 0
+        
+        // 좌우 컬럼에 들어갈 게시글 배열
+        var leftItems: [ContestImageModel] = []
+        var rightItems: [ContestImageModel] = []
+        
+        let columnWidth = (screenWidth - 25) / 2
+        
+        // 모든 게시글을 순차적으로 처리
+        for post in posts {
+            // ratio는 width/height 비율
+            // 실제 화면에서 표시될 이미지 높이 계산
+            // - 현재 뷰의 폭에서 좌우 패딩(9*2) + 컬럼간격(7) = 25 제외
+            // - 남은 폭을 2로 나누어 각 컬럼 폭 구하기
+            // - 컬럼 폭을 ratio로 나누어서 실제 표시 높이 계산 (width/ratio = height)
+            let imageHeight = columnWidth / CGFloat(post.ratio)
+            
+            // 현재 좌우 컬럼의 높이를 비교하여 더 낮은 쪽에 배치
+            if leftHeight <= rightHeight {
+                // 왼쪽이 더 낮거나 같으면 왼쪽에 추가
+                leftItems.append(post)
+                leftHeight += imageHeight + 8 // 이미지 높이 + 컬럼 내 간격
+            } else {
+                // 오른쪽이 더 낮으면 오른쪽에 추가
+                rightItems.append(post)
+                rightHeight += imageHeight + 8 // 이미지 높이 + 컬럼 내 간격
+            }
+        }
+        
+        // 계산 완료된 배열을 State에 적용하여 UI 업데이트 트리거
+        leftColumnPosts = leftItems
+        rightColumnPosts = rightItems
+    }
+}
+
+//#Preview {
+//    WaterfallImageGridView()
+//}

--- a/Soongan/Feature/ContestFeature/Sources/Logic/ContestFeature.swift
+++ b/Soongan/Feature/ContestFeature/Sources/Logic/ContestFeature.swift
@@ -38,23 +38,15 @@ public struct ContestFeature {
         var reportHistories = [Int]()
         var allPosts = [ContestImageModel]()
         var contestOptions = [ContestIndexModel]()
-        var scrollPosition: ScrollPosition = ScrollPosition(idType: ContestImageModel.ID.self)
         
         var isTopButtonVisibility: Bool = false
         
         var contestIndex: Int = 0
         var weekTopic: String = ""
         
-        var leftContestImageList = [ContestImageModel]()
-        var rightContestImageList = [ContestImageModel]()
+        var selectedContestIndex: Int = 0
         
-        var selectedContestIndex: Int = 0 {
-            didSet {
-                print("selectedContestIndex", selectedContestIndex)
-            }
-        }
-        
-        var initPageLoading: Bool = false
+        var initPageLoading: Bool = true
         var isNextPageLoading: Bool = false
         
         var isContestSheetPresented: Bool = false
@@ -120,11 +112,9 @@ public struct ContestFeature {
         
         // 뷰 상태나 레이아웃 관련
         public enum ViewAction {
-            case changeContestIndex
+            case changeContestIndex(to: Int)
             case changeSortContestType(SortContestDataType)
             case updateTopButtonVisibility(CGFloat)
-            case updateLeftImageModel(Int, CGFloat)
-            case updateRightImageModel(Int, CGFloat)
             case updateMoreNextPage(Bool)
             case hideInitialLoading
         }
@@ -165,9 +155,17 @@ public struct ContestFeature {
                     ContestIndexModel(id: $0.id, round: $0.round, subject: $0.subject)
                 }
                 
-                state.contestIndex = state.contestOptions.last?.round ?? 0
-                state.weekTopic = state.contestOptions.last?.subject ?? "정보없음"
-                state.selectedContestIndex = state.contestOptions.count - 1
+                // API에서 첫 번째 값이 최신 콘테스트라는 것을 바탕으로 첫 번째 요소를 사용
+                if let latestContest = state.contestOptions.first {
+                    state.contestIndex = latestContest.round
+                    state.weekTopic = latestContest.subject
+                    state.selectedContestIndex = 0 // 첫 번째 요소가 선택되었으므로 인덱스는 0
+                } else {
+                    // 콘테스트가 없는 경우의 기본값 처리
+                    state.contestIndex = 0
+                    state.weekTopic = "정보없음"
+                    state.selectedContestIndex = 0
+                }
                 
                 return .send(.networkAction(.fetchContestPosts))
                 
@@ -184,7 +182,6 @@ public struct ContestFeature {
                     break
                 }
                 
-                state.scrollPosition.scrollTo(edge: .top)
                 state.currentPageNum = 0
                 
                 let order = state.sortSelectType.rawValue
@@ -247,15 +244,9 @@ public struct ContestFeature {
                 let reportedIDs = Set(state.reportHistories)
                 let newPosts = response.posts
                     .filter { !reportedIDs.contains($0.postId) }
-                    .map { ContestImageModel(id: $0.postId, imageUrl: $0.imageUrl, nickname: $0.nickname) }
+                    .map { ContestImageModel(id: $0.postId, imageUrl: $0.imageUrl, nickname: $0.nickname, reportCount: $0.reportCount, ratio: $0.ratio) }
                 
                 state.allPosts.append(contentsOf: newPosts)
-
-                let (tempLeftList, tempRightList) = rebuildColumnLists(from: state.allPosts)
-                
-                // 마지막에 한 번만 상태를 업데이트하여 View 리렌더링을 최소화
-                state.leftContestImageList = tempLeftList
-                state.rightContestImageList = tempRightList
                 
                 return .run { send in
                     try await Task.sleep(for: .seconds(0.7))
@@ -291,13 +282,6 @@ public struct ContestFeature {
                     state.path.removeLast()
                     state.reportHistories.append(postId)
                     state.allPosts.removeAll { $0.id == postId }
-
-                    // 임시 배열을 사용하여 마스터 리스트를 기준으로 두 개의 컬럼 리스트를 새로 만듦
-                    let (tempLeftList, tempRightList) = rebuildColumnLists(from: state.allPosts)
-                    
-                    // 마지막에 한 번만 상태를 업데이트하여 View 리렌더링을 최소화
-                    state.leftContestImageList = tempLeftList
-                    state.rightContestImageList = tempRightList
                     return .none
                     
                 case .editPost(.delegate(.editCompleted)):
@@ -352,7 +336,8 @@ public struct ContestFeature {
                 
                 return .none
                 
-            case .view(.changeContestIndex):
+            case .view(.changeContestIndex(to: let newIndex)):
+                state.selectedContestIndex = newIndex
                 let contest = state.contestOptions[state.selectedContestIndex]
                 
                 state.contestIndex = contest.round
@@ -368,19 +353,6 @@ public struct ContestFeature {
                 
                 return .send(.networkAction(.fetchContestPosts))
                 
-            case .view(.updateLeftImageModel(let modelId, let imageRatio)):
-                if let index = state.leftContestImageList.firstIndex(where: { $0.id == modelId }) {
-                    state.leftContestImageList[index].height = imageRatio
-                }
-                
-                return .none
-                
-            case .view(.updateRightImageModel(let modelId, let imageRatio)):
-                if let index = state.rightContestImageList.firstIndex(where: { $0.id == modelId }) {
-                    state.rightContestImageList[index].height = imageRatio
-                }
-                
-                return .none
                 
             case .view(.updateTopButtonVisibility(let scrollOffset)):
                 state.isTopButtonVisibility = scrollOffset > 200
@@ -408,21 +380,5 @@ public struct ContestFeature {
             }
         }
         .forEach(\.path, action: \.path)
-    }
-}
-
-
-private extension ContestFeature {
-    func rebuildColumnLists(from allPosts: [ContestImageModel]) -> (left: [ContestImageModel], right: [ContestImageModel]) {
-        var tempLeftList = [ContestImageModel]()
-        var tempRightList = [ContestImageModel]()
-        for (index, post) in allPosts.enumerated() {
-            if index % 2 == 0 {
-                tempLeftList.append(post)
-            } else {
-                tempRightList.append(post)
-            }
-        }
-        return (tempLeftList, tempRightList)
     }
 }

--- a/Soongan/Feature/ContestFeature/Sources/View/ContestIndexSheetView.swift
+++ b/Soongan/Feature/ContestFeature/Sources/View/ContestIndexSheetView.swift
@@ -1,0 +1,62 @@
+//
+//  ContestIndexSheetView.swift
+//  ContestFeature
+//
+//  Created by ParkJunHyuk on 12/24/25.
+//
+
+import SwiftUI
+
+import DesignSystem
+
+import ComposableArchitecture
+
+struct ContestIndexSheetView: View {
+    @Bindable var store: StoreOf<ContestFeature>
+    @State private var selection: Int
+
+    init(store: StoreOf<ContestFeature>) {
+        self.store = store
+        self._selection = State(initialValue: store.state.selectedContestIndex)
+    }
+
+    var body: some View {
+        VStack {
+            HStack {
+                Button(action: {
+                    store.send(.sheet(.dismissContest(false)))
+                }) {
+                    Text("취소")
+                        .font(DesignSystem.Font.semibold16, lineHeight: 19)
+                }
+                
+                Spacer()
+                
+                Text("회차 선택")
+                    .font(DesignSystem.Font.semibold20)
+                
+                Spacer()
+                
+                Button(action: {
+                    store.send(.view(.changeContestIndex(to: selection)))
+                }) {
+                    Text("확인")
+                        .font(DesignSystem.Font.semibold16, lineHeight: 19)
+                }
+            }
+            .padding(.top, 28)
+            .padding(.horizontal, 32)
+            .foregroundStyle(DesignSystem.Color.black100)
+
+            Picker("", selection: $selection) {
+                ForEach(0..<store.contestOptions.count, id: \.self) { index in
+                    let contest = store.contestOptions[index]
+                    Text("\(contest.round)회차 \(contest.subject)")
+                        .tag(index)
+                }
+            }
+            .pickerStyle(.inline)
+        }
+        .frame(maxHeight: .infinity, alignment: .top)
+    }
+}

--- a/Soongan/Feature/ContestFeature/Sources/View/ContestView.swift
+++ b/Soongan/Feature/ContestFeature/Sources/View/ContestView.swift
@@ -39,92 +39,24 @@ public struct ContestView: View {
                 VStack(spacing: 0) {
                     navigationTitle(contestIndex: store.contestIndex, weekTopic: store.weekTopic)
                     
-                    if store.initPageLoading {
-                        // 로딩 중일 때 보여줄 스켈레톤 그리드
-                        HStack(alignment: .top, spacing: 8) {
-                            // 왼쪽 스켈레톤 컬럼
-                            VStack(spacing: 8) {
-                                ForEach(0..<3, id: \.self) { _ in
-                                    SkeletonView()
-                                        .frame(width: geometry.size.width / 2 - 12, height: 200) // 임시 높이
-                                        .cornerRadius(8)
-                                }
-                            }
-                            // 오른쪽 스켈레톤 컬럼
-                            VStack(spacing: 8) {
-                                ForEach(0..<3, id: \.self) { _ in
-                                    SkeletonView()
-                                        .frame(width: geometry.size.width / 2 - 12, height: 250) // 높이를 약간 다르게 하여 자연스러움 추가
-                                        .cornerRadius(8)
-                                }
-                            }
+                    WaterfallImageGridView(
+                        posts: store.allPosts,
+                        hasMorePages: store.hasNextPage,
+                        isLoading: store.isNextPageLoading,
+                        isInitialLoading: store.initPageLoading,
+                        onRefresh: {
+                            store.send(.networkAction(.refreshTriggered))
+                        },
+                        onLoadMore: {
+                            store.send(.view(.updateMoreNextPage(true)))
+                        },
+                        onImageTap: { id in
+                            store.send(.uiAction(.contestDetailImageTapped(id)))
+                        },
+                        onScrollPositionChange: { offsetY in
+                            store.send(.view(.updateTopButtonVisibility(offsetY)))
                         }
-                        .padding(.horizontal, 8)
-                        .transition(.opacity.animation(.easeInOut))
-                    } else {
-                        ZStack(alignment: .bottomTrailing) {
-                            ZStack(alignment: .bottom) {
-                                ScrollView {
-                                    HStack(alignment: .top, spacing: 8) {
-                                        imageGridSection(imageList: store.leftContestImageList, geometry: geometry, direction: .left)
-                                        imageGridSection(imageList: store.rightContestImageList, geometry: geometry, direction: .right)
-                                    }
-                                    .padding(.horizontal, 8)
-                                    .scrollTargetLayout()
-                                    .padding(.bottom, store.isNextPageLoading && store.hasNextPage ? 60 : 0)  // 로딩 공간 확보
-                                }
-                                
-                                // 하단에 고정된 로딩 인디케이터
-                                if store.isNextPageLoading && store.hasNextPage {
-                                    VStack {
-                                        ProgressView()
-                                            .padding(.vertical, 20)
-                                            .frame(maxWidth: .infinity)
-                                            .transition(.move(edge: .bottom))
-                                    }
-                                    .ignoresSafeArea(.container, edges: .bottom)
-                                }
-                            }
-                            .animation(.easeOut(duration: 0.1), value: store.isNextPageLoading)
-                            .scrollPosition($store.scrollPosition, anchor: .bottom)
-                            .refreshable {
-                                try? await Task.sleep(nanoseconds: 1000_000_000)
-                                store.send(.networkAction(.refreshTriggered))
-                            }
-                            .onScrollGeometryChange(for: ScrollPositionState.self) { geometry in
-                                let offsetY = geometry.bounds.origin.y
-                                let reachedBottom = geometry.visibleRect.maxY >= geometry.contentSize.height + 100
-                                return ScrollPositionState(offsetY: offsetY, reachedBottom: reachedBottom)
-                            } action: { oldValue, newValue in
-                                // ScrollView 스크롤 위치가 bottom 에 위치하는지
-                                if oldValue.reachedBottom != newValue.reachedBottom, newValue.reachedBottom {
-                                    if !store.isNextPageLoading {
-                                        store.send(.view(.updateMoreNextPage(newValue.reachedBottom)))
-                                    }
-                                }
-                                
-                                // ScrollView 스크롤 위치를 top 으로 변경
-                                store.send(.view(.updateTopButtonVisibility(newValue.offsetY)))
-                            }
-                            
-                            Button {
-                                withAnimation(.easeInOut) {
-                                    store.scrollPosition.scrollTo(edge: .top)
-                                }
-                            } label: {
-                                Image(systemName: "arrow.up")
-                                    .padding()
-                                    .background(Color.white)
-                                    .foregroundColor(DesignSystem.Color.black100)
-                                    .clipShape(Circle())
-                                    .shadow(radius: 4)
-                                    .padding()
-                            }
-                            .opacity(store.isTopButtonVisibility ? 1 : 0)
-                            .allowsHitTesting(store.isTopButtonVisibility)
-                            .animation(.easeInOut, value: store.isTopButtonVisibility)
-                        }
-                    }
+                    )
                 }
             }
             .safeAreaInset(edge: .bottom, spacing: 0) {
@@ -140,8 +72,9 @@ public struct ContestView: View {
             .sheet(
                 isPresented: $store.isContestSheetPresented.sending(\.sheet.dismissContest)
             ) {
-                changeContestIndexSheet()
+                ContestIndexSheetView(store: self.store)
                     .presentationDetents([.height(280)])
+                    .presentationBackground(DesignSystem.Color.soonganBG)
             }
             .sheet(isPresented: $store.isSortSheetPresented.sending(\.sheet.dismissSortContest)) {
                 CustomSheetView<SortContestDataType>(type: .sortContest, isSelectType: store.sortSelectType) { optionType in
@@ -199,70 +132,6 @@ public struct ContestView: View {
         .background(DesignSystem.Color.soonganBG)
     }
     
-    func imageGridSection(imageList: [ContestImageModel], geometry: GeometryProxy, direction: Direction) -> some View {
-        LazyVStack(spacing: 8) {
-            ForEach(imageList) { model in
-                ContestImageView(
-                    model: model,
-                    geometry: geometry,
-                    onSuccessAction: { modelId, calculatedHeight in
-                        switch direction {
-                        case .left:
-                            store.send(.view(.updateLeftImageModel(modelId, calculatedHeight)))
-                        case .right:
-                            store.send(.view(.updateRightImageModel(modelId, calculatedHeight)))
-                        }
-                    },
-                    onTapAction: { modelId in
-                        store.send(.uiAction(.contestDetailImageTapped(modelId)))
-                    }
-                )
-                .id(model.id)
-            }
-        }
-    }
-}
-
-private extension ContestView {
-    func changeContestIndexSheet() -> some View {
-        VStack {
-            HStack {
-                Button(action: {
-                    store.send(.sheet(.dismissContest(false)))
-                }) {
-                    Text("취소")
-                        .font(DesignSystem.Font.semibold16, lineHeight: 19)
-                }
-                
-                Spacer()
-                
-                Text("회차 선택")
-                    .font(DesignSystem.Font.semibold20)
-                
-                Spacer()
-                
-                Button(action: {
-                    store.send(.view(.changeContestIndex))
-                }) {
-                    Text("확인")
-                        .font(DesignSystem.Font.semibold16, lineHeight: 19)
-                }
-            }
-            .padding(.top, 28)
-            .padding(.horizontal, 32)
-            .foregroundStyle(DesignSystem.Color.black100)
-
-            Picker("", selection: $store.selectedContestIndex) {
-                ForEach(0..<store.contestOptions.count, id: \.self) { index in
-                    let contest = store.contestOptions[index]
-                    Text("\(contest.round)회차 \(contest.subject)")
-                        .tag(index)
-                }
-            }
-            .pickerStyle(.wheel)
-        }
-        .frame(maxHeight: .infinity, alignment: .top)
-    }
 }
 
 // MARK: - Preview

--- a/Soongan/Feature/HomeFeature/Sources/View/HomeView.swift
+++ b/Soongan/Feature/HomeFeature/Sources/View/HomeView.swift
@@ -226,6 +226,8 @@ private extension HomeView {
     func postImageSection(postImageList: [PostImageModel]) -> some View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack(alignment: .top, spacing: 16) {
+                Spacer(minLength: 20)
+                
                 Button(action: {
                     store.send(.uiAction(.addPictureButtonTapped))
                 }) {
@@ -281,7 +283,7 @@ private extension HomeView {
                                     .frame(height: 257)
                                     .shadow(
                                         color: Color.black.opacity(0.25),
-                                        radius: 5, x: 0, y: 4)
+                                        radius: 7, x: 2, y: 4)
                                     .onTapGesture {
                                         store.send(.uiAction(.pictureTapped(image.id)))
                                     }
@@ -316,7 +318,6 @@ private extension HomeView {
                 
                 Spacer(minLength: 20)
             }
-            .padding(.leading, 20)
         }
     }
     

--- a/Soongan/Feature/MypageFeature/Sources/Logic/EditProfileFeature.swift
+++ b/Soongan/Feature/MypageFeature/Sources/Logic/EditProfileFeature.swift
@@ -45,6 +45,10 @@ public struct EditProfileFeature {
     // MARK: - Init
 
     public init() {}
+    
+    // MARK: - Dependency
+    
+    @Dependency(\.userDefaultsClient) var userDefaultsClient
 
     // MARK: - Action
 
@@ -110,7 +114,10 @@ public struct EditProfileFeature {
                 }
                 
             case .editMyProfileSuccess(_):
-                return .send(.delegate(.backButtonTapped))
+                return .run { [nickname = state.nickname] send in
+                    await userDefaultsClient.setString(nickname, forKey: UserDefaultKeys.User.username.rawValue)
+                    await send(.delegate(.backButtonTapped))
+                }
             
             case .baseProfileOptionTapped:
                 state.selectedItem = nil

--- a/Soongan/Feature/MypageFeature/Sources/Logic/MypageFeature.swift
+++ b/Soongan/Feature/MypageFeature/Sources/Logic/MypageFeature.swift
@@ -40,8 +40,10 @@ public struct MypageFeature {
         @Shared(.appStorage("AuthState")) var authState: AuthType = .loggedOut
         var path = StackState<MypagePath.State>()
         
-        var leftContestImageList = [ContestImageModel]()
-        var rightContestImageList = [ContestImageModel]()
+        var allPosts: [ContestImageModel]? = nil
+        var initPageLoading: Bool = true
+        var hasNextPage: Bool = false
+        var isNextPageLoading: Bool = false
         
         var scrollPosition: ScrollPosition = ScrollPosition(idType: ContestIndexModel.ID.self)
         var scrollOffset: CGFloat = 0
@@ -122,8 +124,9 @@ public struct MypageFeature {
         case successSheetComplete(MypageSuccessSheetType)
         case contestDetailImageTapped(Int)
         
-        case updateLeftImageModel(Int, CGFloat)
-        case updateRightImageModel(Int, CGFloat)
+        case updateMoreNextPage(Bool)
+        case updateTopButtonVisibility(CGFloat)
+        case refreshTriggered
         
         case deleteMyInfomation
         
@@ -165,9 +168,11 @@ public struct MypageFeature {
         Reduce { state, action in
             switch action {
             case .onAppear:
+                state.allPosts = nil // 로딩 상태 시작
                 if state.authState == .skipped {
                     state.userName = "로그인이 필요해요"
                     state.userIntroduce = "로그인 후 본인을 소개해주세요"
+                    state.allPosts = [] // 로그인 안했을 시 빈 화면으로
                     return .none
                 }
 
@@ -219,18 +224,17 @@ public struct MypageFeature {
                 return .none
                 
             case .networkAction(.onAppearMyContestInfoSuccess(let response)):
-                state.leftContestImageList.removeAll()
-                state.rightContestImageList.removeAll()
-                
-                for (index, item) in response.postInfo.enumerated() {
-                    let model = ContestImageModel(id: item.postId, imageUrl: item.imageUrl)
-                    if index % 2 == 0 {
-                        state.leftContestImageList.append(model)
-                    } else {
-                        state.rightContestImageList.append(model)
-                    }
+                state.allPosts = response.postInfo.map { item in
+                    ContestImageModel(
+                        id: item.postId,
+                        imageUrl: item.imageUrl,
+                        nickname: nil,
+                        reportCount: item.reportCount,
+                        ratio: item.ratio
+                    )
                 }
 
+                state.initPageLoading = false
                 return .none
                 
             case .networkAction(.onAppearUnReadNotificationSuccess(let response)):
@@ -243,8 +247,7 @@ public struct MypageFeature {
                 return .none
                 
             case .networkAction(.onAppearMyContestInfoFailure):
-                state.leftContestImageList.removeAll()
-                state.rightContestImageList.removeAll()
+                state.allPosts = [] // 요청 실패 시 빈 배열로 설정
                 return .none
                 
             case .networkAction(.onAppearUnReadNotificationFailure):
@@ -500,33 +503,18 @@ public struct MypageFeature {
                 state.isLoginAlertPresented = true
                 return .none
                 
-            case .updateLeftImageModel(let modelId, let imageRatio):
-                if let index = state.leftContestImageList.firstIndex(where: { $0.id == modelId }) {
-                    state.leftContestImageList[index].height = imageRatio
-                }
-                
+            case .updateMoreNextPage(let isLoading):
+                state.isNextPageLoading = isLoading
                 return .none
                 
-            case .updateRightImageModel(let modelId, let imageRatio):
-                if let index = state.rightContestImageList.firstIndex(where: { $0.id == modelId }) {
-                    state.rightContestImageList[index].height = imageRatio
-                }
-                
+            case .updateTopButtonVisibility(let offset):
+                state.scrollOffset = offset
                 return .none
                 
-//            case .logoutSuccess:
-//                return .none
-//                
-//            case .withdrawSuccess:
-//                return .none
-//                
-//            case .presentSheet(let sheetType):
-//                state.activeSheet = sheetType
-//                return .none
-//                
-//            case .notification(_):
-//                return .none
-//                
+            case .refreshTriggered:
+                // 새로고침 로직 (필요시 네트워크 호출)
+                return .none
+                
             default:
                 return .none
             }

--- a/Soongan/Feature/MypageFeature/Sources/Logic/MypageFeature.swift
+++ b/Soongan/Feature/MypageFeature/Sources/Logic/MypageFeature.swift
@@ -176,7 +176,7 @@ public struct MypageFeature {
                     return .none
                 }
 
-                let dto = SearchMyContestRequestDTO(page: 0, pageSize: 50)
+                let dto = SearchMyContestRequestDTO(page: 0, pageSize: 20)
                 
                 return .run { send in
                     async let myInfoResult: Result<SearchMyProfileResponseDTO, NetworkError> = NetworkManager.shared.request(MemberEndpoint.getMembers)
@@ -512,8 +512,18 @@ public struct MypageFeature {
                 return .none
                 
             case .refreshTriggered:
-                // 새로고침 로직 (필요시 네트워크 호출)
-                return .none
+                let dto = SearchMyContestRequestDTO(page: 0, pageSize: 20)
+                
+                return .run { send in
+                    let myContestInfoResult: Result<SearchMyContestResponseDTO, NetworkError> = await NetworkManager.shared.request(WeeklyContestEndpoint.getMyContest(dto))
+                    
+                    switch myContestInfoResult {
+                    case .success(let contest):
+                        await send(.networkAction(.onAppearMyContestInfoSuccess(contest)))
+                    case .failure(let error):
+                        await send(.networkAction(.onAppearMyContestInfoFailure(error)))
+                    }
+                }
                 
             default:
                 return .none

--- a/Soongan/Feature/MypageFeature/Sources/View/MypageView.swift
+++ b/Soongan/Feature/MypageFeature/Sources/View/MypageView.swift
@@ -16,6 +16,11 @@ import ExplainFeature
 import ComposableArchitecture
 import Kingfisher
 
+// 기존 Direction enum - 주석처리된 코드에서 필요 (추후 완전 제거 예정)
+enum Direction {
+    case left, right
+}
+
 public struct MypageView: View {
     
     @Bindable var store: StoreOf<MypageFeature>
@@ -57,10 +62,49 @@ public struct MypageView: View {
                 }
                 .padding(EdgeInsets(top: 21, leading: 18, bottom: 26, trailing: 28))
                 
-                if store.leftContestImageList.isEmpty {
-                    notJoinContestSection()
+                if let posts = store.allPosts {
+                    if posts.isEmpty {
+                        notJoinContestSection()
+                    } else {
+                        WaterfallImageGridView(
+                            posts: posts,
+                            hasMorePages: store.hasNextPage,
+                            isLoading: store.isNextPageLoading,
+                            isInitialLoading: false, // 로딩 완료
+                            onRefresh: {
+                                store.send(.refreshTriggered)
+                            },
+                            onLoadMore: {
+                                store.send(.updateMoreNextPage(true))
+                            },
+                            onImageTap: { id in
+                                store.send(.contestDetailImageTapped(id))
+                            },
+                            onScrollPositionChange: { offsetY in
+                                store.send(.updateTopButtonVisibility(offsetY))
+                            }
+                        )
+                    }
                 } else {
-                    contestImageSection()
+                    // 상태 1: 초기 로딩 중 (nil)
+                    WaterfallImageGridView(
+                        posts: [], // 로딩 중에는 빈 배열 전달
+                        hasMorePages: false,
+                        isLoading: false,
+                        isInitialLoading: true,
+                        onRefresh: {
+                            store.send(.refreshTriggered)
+                        },
+                        onLoadMore: {
+                            // 필요시 로직 추가
+                        },
+                        onImageTap: { _ in
+                            // 로딩 중에는 탭 동작 없음
+                        },
+                        onScrollPositionChange: { _ in
+                            // 필요시 로직 추가
+                        }
+                    )
                 }
             }
             .frame(maxHeight: .infinity)
@@ -122,72 +166,6 @@ public struct MypageView: View {
                 ExplainView(store: store)
             case .completeExplain(let store):
                 CompleteExplainView(store: store)
-            }
-        }
-    }
-    
-    func contestImageSection() -> some View {
-        GeometryReader { geometry in
-            ZStack(alignment: .bottomTrailing) {
-                ScrollView {
-                    HStack(alignment: .top, spacing: 8) {
-                        imageGridSection(imageList: store.leftContestImageList, geometry: geometry, direction: .left)
-                        imageGridSection(imageList: store.rightContestImageList, geometry: geometry, direction: .right)
-                    }
-                    .padding(.horizontal, 8)
-                    .scrollTargetLayout()
-                }
-                .scrollPosition($store.scrollPosition, anchor: .bottom)
-                .onScrollGeometryChange(for: CGFloat.self,
-                    of: { geometry in
-                        return geometry.bounds.origin.y
-                    },
-                    action: { oldValue, newValue in
-                        withAnimation {
-                            store.scrollOffset = newValue
-                        }
-                    }
-                )
-                
-                Button {
-                    withAnimation(.easeInOut) {
-                        store.scrollPosition.scrollTo(edge: .top)
-                    }
-                } label: {
-                    Image(systemName: "arrow.up")
-                        .padding()
-                        .background(Color.white)
-                        .foregroundColor(DesignSystem.Color.black100)
-                        .clipShape(Circle())
-                        .shadow(radius: 4)
-                        .padding()
-                }
-                .opacity(store.scrollOffset > 200 ? 1 : 0)
-                .allowsHitTesting(store.scrollOffset > 200)
-                .animation(.easeInOut, value: store.scrollOffset > 200)
-            }
-            .padding(.bottom, 50)
-        }
-    }
-    
-    func imageGridSection(imageList: [ContestImageModel], geometry: GeometryProxy, direction: Direction) -> some View {
-        LazyVStack(spacing: 8) {
-            ForEach(imageList) { model in
-                ContestImageView(
-                    model: model,
-                    geometry: geometry,
-                    onSuccessAction: { modelId, calculatedHeight in
-                        switch direction {
-                        case .left:
-                            store.send(.updateLeftImageModel(modelId, calculatedHeight))
-                        case .right:
-                            store.send(.updateRightImageModel(modelId, calculatedHeight))
-                        }
-                    },
-                    onTapAction: { modelId in
-                        store.send(.contestDetailImageTapped(modelId))
-                    }
-                )
             }
         }
     }

--- a/Soongan/Feature/MypageFeature/Sources/View/MypageView.swift
+++ b/Soongan/Feature/MypageFeature/Sources/View/MypageView.swift
@@ -16,11 +16,6 @@ import ExplainFeature
 import ComposableArchitecture
 import Kingfisher
 
-// 기존 Direction enum - 주석처리된 코드에서 필요 (추후 완전 제거 예정)
-enum Direction {
-    case left, right
-}
-
 public struct MypageView: View {
     
     @Bindable var store: StoreOf<MypageFeature>

--- a/Soongan/Project.swift
+++ b/Soongan/Project.swift
@@ -5,7 +5,7 @@ import ProjectDescription
 let projectSettings: Settings = .settings(
     base: [
         "MARKETING_VERSION": "1.0.0",
-        "CURRENT_PROJECT_VERSION": "3",
+        "CURRENT_PROJECT_VERSION": "6",
         "DEVELOPMENT_TEAM": "9QK3G4VF9N",
         "OTHER_LDFLAGS": ["-all_load"]
     ],

--- a/Soongan/Shared/Sources/Model/ContestImageModel.swift
+++ b/Soongan/Shared/Sources/Model/ContestImageModel.swift
@@ -11,17 +11,20 @@ public struct ContestImageModel: Identifiable, Hashable {
     public var id: Int
     public let imageUrl: String
     public let nickname: String?
-    public var height: CGFloat?
+    public let reportCount: Int
+    public let ratio: Double
     
     public init(
         id: Int,
         imageUrl: String,
-        nickname: String? = nil,
-        height: CGFloat? = nil
+        nickname: String?,
+        reportCount: Int,
+        ratio: Double
     ) {
         self.id = id
         self.imageUrl = imageUrl
         self.nickname = nickname
-        self.height = height
+        self.reportCount = reportCount
+        self.ratio = ratio
     }
 }


### PR DESCRIPTION
## 📟 관련 이슈
- Resolved: #54 

<br>

## 👷 작업한 내용
<!-- 작업한 내용을 적어주세요. -->
- 마이페이지 '내 작품' 목록의 로딩, 빈 상태, 데이터 상태 처리 구현
- `WaterfallImageGridView` 컴포넌트 추가 및 마이페이지/콘테스트 뷰 적용
- 콘테스트 뷰의 최신 회차 선택 로직 오류 수정
- 콘테스트 회차 선택 피커(Picker)의 레이스 컨디션 문제 해결
- 레거시 UI 코드 제거 및 전반적인 리팩토링

<br>

## 🚨 참고 사항
<!-- 참고 사항을 적어주세요. 없으면 지워주세요. -->
### 1. 마이페이지 기능 개선
- 문제점: 기존에는 마이페이지 '내 작품' 목록에 로딩 상태나 데이터가 없는 상태가 명확히 구분되지 않아 사용자 경험이 좋지 않았습니다.
- 해결책: MyPageFeature의 allPosts 상태를옵셔널([ContestImageModel]?)로 변경하여 로딩(`nil`), 빈 상태(`[]`), 데이터 있음(`[...]`) 세 가지 상태를 명확히 구분했습니다.
- 구현:
    - `WaterfallImageGridView` 를 새로 구현하여 `isInitialLoading` 프로퍼티를 통해 로딩 스켈레톤 UI를 표시하도록 했습니다.
    - `MyPageView` 는 `allPosts` 의 상태에 따라 `WaterfallImageGridView` 의 로딩상태를 제어하거나, 데이터가 없을 경우 "아직 참가한 내역이 없어요" 메시지를 표시합니다.

### 2. 콘테스트 피커 안정성 강화
- 문제점: API 응답 순서에 의존하여 최신 회차를 잘못 선택하는 오류가 있었습니다.
- 해결책: API 스펙에 따라 항상 첫 번째 요소가 최신 회차이므로, `.first` 를 사용하여 명시적으로 첫 번째 콘테스트를 선택하도록 수정했습니다.

### 3. 리팩토링 및 공통 컴포넌트
- `WaterfallImageGridView` 를 `DesignSystem` 모듈에 추가하여 재사용 가능한 컴포넌트로 만들었습니다.
- `ContestImageModel` 및 관련 DTO에 이미지 비율(`ratio`)과 신고 횟수(`reportCount`)를 추가하여 `WaterfallImageGridView` 에서 활용하도록 했습니다.
- 마이페이지와 콘테스트 뷰에서 더 이상 사용되지 않는 레거시 2-컬럼 레이아웃 관련 코드를 모두 제거했습니다.

<br>

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
